### PR TITLE
Two new configuration options; useful for theming

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -205,6 +205,8 @@ $.extend($.validator, {
 		errorClass: "error",
 		validClass: "valid",
 		errorElement: "label",
+		appendToError: false,
+		prependToError: false,
 		focusInvalid: true,
 		errorContainer: $( [] ),
 		errorLabelContainer: $( [] ),
@@ -631,13 +633,23 @@ $.extend($.validator, {
 				label.removeClass().addClass( this.settings.errorClass );
 
 				// check if we have a generated label, replace the message then
-				label.attr("generated") && label.html(message);
+				if (label.attr("generated")) {
+					label.html(message);
+					if ( this.settings.appendToError )
+							label.append( this.settings.appendToError );
+					if ( this.settings.prependToError )
+							label.prepend( this.settings.prependToError );
+				}
 			} else {
 				// create label
 				label = $("<" + this.settings.errorElement + "/>")
 					.attr({"for":  this.idOrName(element), generated: true})
 					.addClass(this.settings.errorClass)
 					.html(message || "");
+				if ( this.settings.appendToError )
+					label.append( this.settings.appendToError );
+				if ( this.settings.prependToError )
+					label.prepend( this.settings.prependToError );
 				if ( this.settings.wrapper ) {
 					// make sure the element is visible, even in IE
 					// actually showing the wrapped element is handled elsewhere


### PR DESCRIPTION
Added 2 new options:
- appendToError [default: false]
- prependToError [default: false]

If specified, they will append or prepend content within all error elements.
They accept anything that jQuery's .prepend and .append methods accept.

These options are useful when making themed errors (e.g. speech bubbles) and need elements in your error containers to represent things (e.g. speech bubble arrow).

```
<label ...><em></em>Error message goes here</label>
```
