### PR TITLE
Added two input type selectors useful for MobileSafari

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -303,7 +303,7 @@ $.extend($.validator, {
 				validator.settings[eventType] && validator.settings[eventType].call(validator, this[0] );
 			}
 			$(this.currentForm)
-				.validateDelegate(":text, :password, :file, select, textarea", "focusin focusout keyup", delegate)
+				.validateDelegate(":text, :password, :file, select, textarea, input[type=number], input[type=tel]", "focusin focusout keyup", delegate)
 				.validateDelegate(":radio, :checkbox, select, option", "click", delegate);
 
 			if (this.settings.invalidHandler)


### PR DESCRIPTION
We added additional selectors for `<input type="number">` and `<input type="tel">` to allow key-press validation checking on inputs commonly used in webpages targeted Mobile Safari. These input types behave the same as `type="text"` except for triggering a numeric soft-keyboard on iOS.
