### PR TITLE
Your $.ajax = function (settings) { ... } prevents JSON POST via jqgrid plugin using jquery 1.5

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1085,14 +1085,17 @@ $.format = $.validator.format;
 // ajax mode: abort
 // usage: $.ajax({ mode: "abort"[, port: "uniqueport"]});
 // if mode:"abort" is used, the previous request on that port (port can be undefined) is aborted via XMLHttpRequest.abort() 
+// ajax mode: abort
+// usage: $.ajax({ mode: "abort"[, port: "uniqueport"]});
+// if mode:"abort" is used, the previous request on that port (port can be undefined) is aborted via XMLHttpRequest.abort() 
 ;(function($) {
 	var ajax = $.ajax;
 	var pendingRequests = {};
 	$.ajax = function(settings) {
-		// create settings for compatibility with ajaxSetup
-		settings = $.extend(settings, $.extend({}, $.ajaxSettings, settings));
-		var port = settings.port;
-		if (settings.mode == "abort") {
+        // get read-only settings for compatibility with ajaxSetup
+		var localSettings = $.extend({}, $.ajaxSettings, settings);
+		var port = localSettings.port;		
+		if (localSettings.mode == "abort") {
 			if ( pendingRequests[port] ) {
 				pendingRequests[port].abort();
 			}


### PR DESCRIPTION
Problem: $.ajax override prevents JSON POST via jqgrid 3.8.2 plugin using jquery 1.5.  

Pull request submitted via github 2/18/2011.  If a full blown test case is needed, please e-mail me.

Solution: Please review code change and rerun your unit tests.  Analysis of your code appears to suggest that this method is not responsible for altering the settings.  Therefore, I changed the behavior to get the settings to a local variable.  This is a serious issue as I believe it breaks jqgrid.  At least for my use case using JSON/POST.
