### PR TITLE
Allow spaces in credit card numbers

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1034,8 +1034,8 @@ $.extend($.validator, {
 		creditcard: function(value, element) {
 			if ( this.optional(element) )
 				return "dependency-mismatch";
-			// accept only digits and dashes
-			if (/[^0-9-]+/.test(value))
+			// accept only digits, dashes, and spaces
+			if (/[^0-9- ]+/.test(value))
 				return false;
 			var nCheck = 0,
 				nDigit = 0,

--- a/test/methods.js
+++ b/test/methods.js
@@ -338,8 +338,11 @@ test("equalTo", function() {
 
 test("creditcard", function() {
 	var method = methodTest("creditcard");
-	ok( method( "446-667-651" ), "Valid creditcard number" );
-	ok( !method( "asdf" ), "Invalid creditcard number" );
+	ok( method( "446667651" ), "Valid creditcard number all numbers" );
+	ok( method( "446-667-651" ), "Valid creditcard number with dashes" );
+	ok( method( "446 667 651" ), "Valid creditcard number with spaces" );
+	ok( !method( "asdf" ), "Invalid characters in creditcard number" );
+	ok( !method( "1234-1234-1234-1234" ), "Fails checksum" );
 });
 
 test("accept", function() {


### PR DESCRIPTION
Resolves jzaefferer/jquery-validation#32.

This patch differs from the existing pull request in the following ways:
- it adds test coverage for the modified behavior
- it updates the comment on jquery.validate.js:1035 to be accurate (spaces are now allowed)
- I didn't update the minified and packed versions or the zip file. I feel that is something that is probably automated at release time.
