### PR TITLE
Added email as a validatable type

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -303,7 +303,7 @@ $.extend($.validator, {
 				validator.settings[eventType] && validator.settings[eventType].call(validator, this[0] );
 			}
 			$(this.currentForm)
-				.validateDelegate(":text, :password, :file, select, textarea", "focusin focusout keyup", delegate)
+				.validateDelegate(":text, :password, :file, select, textarea, [type=email]",  "focusin focusout keyup", delegate)
 				.validateDelegate(":radio, :checkbox, select, option", "click", delegate);
 
 			if (this.settings.invalidHandler)


### PR DESCRIPTION
This is a one-line change to allow validation of the HTML5 email type.  It could probably be expanded to handle other HTML form types, but this is the one I needed right now. 
