### PR TITLE
Added "errorPosition" option, used to position an error element even if it already exists.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -654,6 +654,9 @@ $.extend($.validator, {
 					? label.addClass( this.settings.success )
 					: this.settings.success( label );
 			}
+
+			this.settings.errorPosition && this.settings.errorPosition( label, $(element) );
+
 			this.toShow = this.toShow.add(label);
 		},
 


### PR DESCRIPTION
Added "errorPosition" option. This option (function) should be used to customize the positioning of an error element. Unlike "errorPlacement", this function will always be called should it exist, i.e. even after an error element has already been added. This is especially useful when pairing this plugin with server-side validation. In this situation, the error element is already in the DOM, yet we still want to position it properly (e.g. absolutely positioned to the right of the form control).
