### PR TITLE
Pass event to handler functions

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -211,7 +211,7 @@ $.extend($.validator, {
 		onsubmit: true,
 		ignore: [],
 		ignoreTitle: false,
-		onfocusin: function(element) {
+		onfocusin: function(element, event) {
 			this.lastActive = element;
 
 			// hide error label and remove error class on focus if enabled
@@ -220,17 +220,17 @@ $.extend($.validator, {
 				this.addWrapper(this.errorsFor(element)).hide();
 			}
 		},
-		onfocusout: function(element) {
+		onfocusout: function(element, event) {
 			if ( !this.checkable(element) && (element.name in this.submitted || !this.optional(element)) ) {
 				this.element(element);
 			}
 		},
-		onkeyup: function(element) {
+		onkeyup: function(element, event) {
 			if ( element.name in this.submitted || element == this.lastElement ) {
 				this.element(element);
 			}
 		},
-		onclick: function(element) {
+		onclick: function(element, event) {
 			// click on selects, radiobuttons and checkboxes
 			if ( element.name in this.submitted )
 				this.element(element);
@@ -308,7 +308,7 @@ $.extend($.validator, {
 			function delegate(event) {
 				var validator = $.data(this[0].form, "validator"),
 					eventType = "on" + event.type.replace(/^validate/, "");
-				validator.settings[eventType] && validator.settings[eventType].call(validator, this[0] );
+				validator.settings[eventType] && validator.settings[eventType].call(validator, this[0], event);
 			}
 			$(this.currentForm)
 				.validateDelegate(":text, :password, :file, select, textarea", "focusin focusout keyup", delegate)


### PR DESCRIPTION
I tried to override defaults.onkeyup function to disregard TAB key (saw no reasoning why validation magic should be triggered upon tab) only to find out that I have no idea of the event specifics (event.which, for this use-case).

Another idea is to ignore tab by default, but perhaps there is an explanation why this is not done?
