### PR TITLE
Adding event object to submitHandler

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -58,7 +58,7 @@ $.extend($.fn, {
 							// insert a hidden input as a replacement for the missing submit button
 							var hidden = $("<input type='hidden'/>").attr("name", validator.submitButton.name).val(validator.submitButton.value).appendTo(validator.currentForm);
 						}
-						validator.settings.submitHandler.call( validator, validator.currentForm );
+						validator.settings.submitHandler.call( validator, validator.currentForm, event );
 						if (validator.submitButton) {
 							// and clean up afterwards; thanks to no-block-scope, hidden can be referenced
 							hidden.remove();


### PR DESCRIPTION
Adding form event object to the submitHandler, allowing the event to supress the form submit in the case of submitting using JavaScript (ie - AJAX form submisions)
