### PR TITLE
Form invalid callback

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -81,6 +81,9 @@ $.extend($.fn, {
 					return handle();
 				} else {
 					validator.focusInvalid();
+                    if ( validator.settings.oninvalid ) {
+                      validator.settings.oninvalid.call(this);
+                    }
 					return false;
 				}
 			});


### PR DESCRIPTION
Hi,

I added a oninvalid-callback for when form is invalid, to allow you to know when the form is invalid. I needed this due to a very specific layout issue, where I had to resize the containing element. 

The naming is modeled efter the invalid-event in the HTML5 specification. This isn't adding a lot of overhead. 
