### PR TITLE
remote() can now accept JSON or a simple boolean as the response

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -951,7 +951,13 @@ $.extend($.validator, {
 				data: data,
 				success: function(response) {
 					validator.settings.messages[element.name].remote = previous.originalMessage;
-					var valid = response === true;
+					
+					if (typeof response === "boolean") {
+						var valid = response === true;
+					} else {
+						var valid = response.valid === true;
+					}
+					
 					if ( valid ) {
 						var submitted = validator.formSubmitted;
 						validator.prepareElement(element);
@@ -964,6 +970,7 @@ $.extend($.validator, {
 						errors[element.name] = previous.message = $.isFunction(message) ? message(value) : message;
 						validator.showErrors(errors);
 					}
+					
 					previous.valid = valid;
 					validator.stopRequest(element, valid);
 				}


### PR DESCRIPTION
I modified the success callback of the remote method to test whether the response is a boolean value or whether it's something different (JSON). This will allow developers to pack other things (if necessary) into the response of their server-side script and access that data in an overridden success callback provided by jQuery.validate's constructor options. It greatly expands the scope of what the remote method can do.

The JSON response must be valid, but can contain any data as long as the key "valid" is filled out, as shown:

``` javascript
{ "valid": true }
```

This generic key "valid" is the replacement for the simple boolean value that was the entire contents of the response.

By the way, both this plugin and require.js are SUPER useful on a daily basis. Thank you so much for making them!!
