### PR TITLE
Added in support for HTML 5 input types

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -311,7 +311,12 @@ $.extend($.validator, {
 				validator.settings[eventType] && validator.settings[eventType].call(validator, this[0] );
 			}
 			$(this.currentForm)
-				.validateDelegate(":text, :password, :file, select, textarea", "focusin focusout keyup", delegate)
+			       .validateDelegate(":text, :password, :file, select, textarea, " +
+						"[type='number'], [type='search'] ,[type='tel'], [type='url'], " +
+						"[type='email'], [type='datetime'], [type='date'], [type='month'], " +
+						"[type='week'], [type='time'], [type='datetime-local'], " +
+						"[type='range'], [type='color'] ", 
+						"focusin focusout keyup", delegate)
 				.validateDelegate(":radio, :checkbox, select, option", "click", delegate);
 
 			if (this.settings.invalidHandler)


### PR DESCRIPTION
There are two issues, asking for support for inputs of type=number  :

https://github.com/jzaefferer/jquery-validation/issues/97
https://github.com/jzaefferer/jquery-validation/issues/114

This patch, should add support for html 5 input types.
