### PR TITLE
showLabel() removing all classes from the error element

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -628,7 +628,7 @@ $.extend($.validator, {
 			var label = this.errorsFor( element );
 			if ( label.length ) {
 				// refresh error/success class
-				label.removeClass().addClass( this.settings.errorClass );
+				label.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
 
 				// check if we have a generated label, replace the message then
 				label.attr("generated") && label.html(message);


### PR DESCRIPTION
showLabel() was removing all classes from the error element before re-adding the error class.

This is likely unwanted behavior when manually adding classes to error messages through overridden methods such as errorPlacement().
