### PR TITLE
fixed translation pt_BR

### DIFF
--- a/localization/messages_ptbr.js
+++ b/localization/messages_ptbr.js
@@ -9,7 +9,7 @@ jQuery.extend(jQuery.validator.messages, {
 	url: "Por favor, forne&ccedil;a uma URL v&aacute;lida.",
 	date: "Por favor, forne&ccedil;a uma data v&aacute;lida.",
 	dateISO: "Por favor, forne&ccedil;a uma data v&aacute;lida (ISO).",
-	number: "Por favor, forne&ccedil;a um n&uacute;mero v&aacute;lida.",
+	number: "Por favor, forne&ccedil;a um n&uacute;mero v&aacute;lido.",
 	digits: "Por favor, forne&ccedil;a somente d&iacute;gitos.",
 	creditcard: "Por favor, forne&ccedil;a um cart&atilde;o de cr&eacute;dito v&aacute;lido.",
 	equalTo: "Por favor, forne&ccedil;a o mesmo valor novamente.",


### PR DESCRIPTION
Fixed translated number gender , we don't say "numero valida", "numero" is a "masculine" word, so we say "numero valido" instead of "numero valida"
