### PR TITLE
Pattern additional method

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -278,3 +278,21 @@ jQuery.validator.addMethod("ipv4", function(value, element, param) {
 jQuery.validator.addMethod("ipv6", function(value, element, param) { 
     return this.optional(element) || /^((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}:[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){5}:([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){4}:([0-9A-Fa-f]{1,4}:){0,2}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){3}:([0-9A-Fa-f]{1,4}:){0,3}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){2}:([0-9A-Fa-f]{1,4}:){0,4}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){6}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(([0-9A-Fa-f]{1,4}:){0,5}:((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|(::([0-9A-Fa-f]{1,4}:){0,5}((\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b)\.){3}(\b((25[0-5])|(1\d{2})|(2[0-4]\d)|(\d{1,2}))\b))|([0-9A-Fa-f]{1,4}::([0-9A-Fa-f]{1,4}:){0,5}[0-9A-Fa-f]{1,4})|(::([0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4})|(([0-9A-Fa-f]{1,4}:){1,7}:))$/i.test(value);
 }, "Please enter a valid IP v6 address.");
+
+/**
+  * Return true if the field value matches the given format RegExp
+  *
+  * @example jQuery.validator.methods.pattern("AR1004",element,/^AR\d{4}$/) 
+  * @result true
+  *
+  * @example jQuery.validator.methods.pattern("BR1004",element,/^AR\d{4}$/) 
+  * @result false
+  *
+  * @name jQuery.validator.methods.pattern
+  * @type Boolean
+  * @cat Plugins/Validate/Methods
+  */
+jQuery.validator.addMethod("pattern", function(value, element, param) {
+    return this.optional(element) || param.test(value);
+}, "Invalid format.");
+

--- a/test/methods.js
+++ b/test/methods.js
@@ -515,6 +515,12 @@ test("maxWords", function() {
 	ok( !method("<b>hello</b> world", 2), "html, invalid" );
 });
 
+test("pattern", function() {
+	var method = methodTest("pattern");
+	ok( method( "AR1004", /^AR\d{4}$/ ), "Correct format for the given RegExp" );
+	ok( !method( "BR1004", /^AR\d{4}$/ ), "Invalid format for the given RegExp" );
+});
+
 function testCardTypeByNumber(number, cardname, expected) {
 	$("#cardnumber").val(number);
 	var actual = $("#ccform").valid();
@@ -582,3 +588,4 @@ test('creditcardtypes, mastercard', function() {
 });
 
 })(jQuery);
+


### PR DESCRIPTION
In some cases a really special format may apply to a field and, although is not that hard to create a whole new validation for it, a flexible format validation based on regexps is a good solution.
### Usage

``` javascript
$('#form_id_here').validate(
    rules: { 
        filed_name_here: {
            pattern: /format_regexp_here/
        }
    }
    messages: {
        filed_name_here: {
            pattern: 'optional_error_message_here'
        }
    }
);
```
