### PR TITLE
Lazy validation option

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -207,6 +207,7 @@ $.extend($.validator, {
 		messages: {},
 		groups: {},
 		rules: {},
+		lazy: {},
 		errorClass: "error",
 		validClass: "valid",
 		errorElement: "label",
@@ -231,7 +232,7 @@ $.extend($.validator, {
 			}
 		},
 		onkeyup: function(element, event) {
-			if ( element.name in this.submitted || element == this.lastElement ) {
+			if (!this.lazy(element) && (element.name in this.submitted || element == this.lastElement)) {
 				this.element(element);
 			}
 		},
@@ -684,6 +685,10 @@ $.extend($.validator, {
 
 		checkable: function( element ) {
 			return /radio|checkbox/i.test(element.type);
+		},
+
+		lazy: function(element) {
+			return element.name in this.settings.lazy || $(element).hasClass('lazy');
 		},
 
 		findByName: function( name ) {


### PR DESCRIPTION
Here's a small addition to always validate some fields lazily. There's a new setting, `lazy`, that holds an object with field names as keys; values are ignored. Alternatively, an input can be given the class "lazy". Any fields marked lazy won't be validated during a keyup event (I'm not sure that, strictly speaking, this counts as "lazy", but it sure isn't eager), which is useful for certain types of data, such as credit card numbers, and for suppressing validation feedback when giving feedback during input masking.

Example:

```
<form>
    <input class="digits required" name="foo" id="foo"/>
    <input class="digits required lazy" name="bar" id="bar"/>
    <input class="digits required" name="baz" id="baz"/>
</form>
<script type="text/javascript">
$('form').validate({lazy: {foo: 1}});
</script>
```
