### PR TITLE
For correct working 'required' rule as attribute value

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -791,6 +791,10 @@ $.extend($.validator, {
 
 		for (var method in $.validator.methods) {
 			var value = $element.attr(method);
+			// In attributes any value for 'required' attribute _ALWAYS_ will be 'required' as string type.
+			// For correct working we need setup only boolean true value else this method as attribute is useless
+			if (method === "required" && value)
+				value = true;
 			if (value) {
 				rules[method] = value;
 			} else if ($element[0].getAttribute("type") === method) {


### PR DESCRIPTION
Current version has bug - i cannot use 'required' rule as attribute

For example Firefox sets always only one value for $(elem).attr('required') - "required" value
So we can use only one way for "required" rule as attribute - boolean type. But boolean type is not available now - there will be always string type and there will run string version of required for attribute "required" - and always will valid() for such fields....

This patch corrects this behavior (tested)

Please update validation pluging! :)
