### PR TITLE
Performance of a large form on IE6

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -448,8 +448,7 @@ $.extend($.validator, {
 
 			// select all valid inputs inside the form (no submit or reset buttons)
 			return $(this.currentForm)
-			.find("input, select, textarea")
-			.not(":submit, :reset, :image, [disabled]")
+			.find(":input:not(:submit, :reset, :image, [disabled],button)")
 			.not( this.settings.ignore )
 			.filter(function() {
 				!this.name && validator.settings.debug && window.console && console.error( "%o has no name assigned", this);


### PR DESCRIPTION
This is an fix similar to d3f9b4660a from Adam Tibi for performance of the this.find("input, button") selector.

On IE6, this particular selector spends most of it's time merging the results from the individual queries of input and buttons.  By limiting the criteria for the query with the class selector for cancel, this operation takes significantly less time.

On the particular page I was working on, calling .validate() went from 3 seconds to 300 milliseconds.
