### PR TITLE
calling valid() on elements with dependacy-callback or dependacy-expression haven't been working.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -353,8 +353,8 @@ $.extend($.validator, {
 			this.lastElement = element;
 			this.prepareElement( element );
 			this.currentElements = $(element);
-			var result = this.check( element );
-			if ( result ) {
+			var result = this.check( element ) !== false ;
+			if ( result) {
 				delete this.invalid[element.name];
 			} else {
 				this.invalid[element.name] = true;


### PR DESCRIPTION
fix: element() was directly using check() return value. check() return precisely false if element is invalid. all other values or no value at all mark a valid element
