### PR TITLE
Pass submit event to submitHandler callback

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -63,7 +63,7 @@ $.extend($.fn, {
 							// insert a hidden input as a replacement for the missing submit button
 							var hidden = $("<input type='hidden'/>").attr("name", validator.submitButton.name).val(validator.submitButton.value).appendTo(validator.currentForm);
 						}
-						validator.settings.submitHandler.call( validator, validator.currentForm );
+						validator.settings.submitHandler.call( validator, validator.currentForm, event );
 						if (validator.submitButton) {
 							// and clean up afterwards; thanks to no-block-scope, hidden can be referenced
 							hidden.remove();


### PR DESCRIPTION
To call return false in the submitHandler callback to cancel the form submit didn't do it for my use-case. I have a lot of things going on after a cancelled submit so instead I passed the actual submit event to the callback in order to at the top do event.preventDefault();

submitHandler: function(form, event) {
   event.preventDefault();
   …
   …
}
