### PR TITLE
equalTo method will not validate the element on blur if onfocusout is set to false

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1092,9 +1092,12 @@ $.extend($.validator, {
 		equalTo: function(value, element, param) {
 			// bind to the blur event of the target in order to revalidate whenever the target field is updated
 			// TODO find a way to bind the event just once, avoiding the unbind-rebind overhead
-			var target = $(param).unbind(".validate-equalTo").bind("blur.validate-equalTo", function() {
-				$(element).valid();
-			});
+			var target = $(param);
+			if (this.settings.onfocusout) {
+				target.unbind(".validate-equalTo").bind("blur.validate-equalTo", function() {
+					$(element).valid();
+				});
+			}
 			return value == target.val();
 		}
 

--- a/test/test.js
+++ b/test/test.js
@@ -161,6 +161,22 @@ test("form(): with equalTo", function() {
 	ok( v.form(), 'Valid form' );
 });
 
+test("form(): with equalTo and onfocusout=false", function() {
+	expect( 4 );
+	var form = $('#testForm5')[0];
+	var v = $(form).validate({
+		onfocusout: false,
+		showErrors: function() {
+			ok(true, 'showErrors should only be called twice');
+			this.defaultShowErrors();
+		}
+	});
+	$('#x1, #x2').val("hi");
+	ok( v.form(), 'Valid form' );
+	$('#x2').val('not equal').blur();
+	ok( !v.form(), 'Invalid form' );
+});
+
 test("check(): simple", function() {
 	expect( 3 );
 	var element = $('#firstname')[0];


### PR DESCRIPTION
[http://jsfiddle.net/dsvzX/3/](This jsFiddle) shows the problem in action.

I modified the equalTo method to only bind to the target element's blur event if the onfocusout options is set to true. I also added a test case.

Let me know what you think.
