### PR TITLE
Fixed ignore option to avoid undefined and get :input elements

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -682,9 +682,9 @@ $.extend($.validator, {
 		validationTargetFor: function(element) {
 			// if radio/checkbox, validate first element in group instead
 			if (this.checkable(element)) {
-				element = this.findByName( element.name ).not(this.settings.ignore)[0];
+				element = this.findByName( element.name );
 			}
-			return element;
+			return $(element).not(this.settings.ignore)[0];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
When we have a check or radio element and it is `:hidden` the defaut `ignore` option don't get it, then `undefined` is returned and breaks the script. It should be just ignored and skipped.
