### PR TITLE
errorClass option can't handle multiple class names

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -470,7 +470,8 @@ $.extend($.validator, {
 		},
 
 		errors: function() {
-			return $( this.settings.errorElement + "." + this.settings.errorClass, this.errorContext );
+			var errorClass = this.settings.errorClass.replace(' ', '.');
+			return $( this.settings.errorElement + "." + errorClass, this.errorContext );
 		},
 
 		reset: function() {


### PR DESCRIPTION
Using multiple class names for errorClass option causes duplicate error messages. Old error message does not disappear when new error message is generated. This is because multiple classes are not handled correctly by error selector function.

Example:

``` javascript
$(".selector").validate({
   errorClass: "invalid red"
})
```
