### PR TITLE
Correcting "maxWords" validation method behavior.

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -20,7 +20,7 @@
 		.replace(/[0-9.(),;:!?%#$'"_+=\/-]*/g,'');
 	}
 	jQuery.validator.addMethod("maxWords", function(value, element, params) {
-	    return this.optional(element) || stripHtml(value).match(/\b\w+\b/g).length < params;
+	    return this.optional(element) || stripHtml(value).match(/\b\w+\b/g).length <= params;
 	}, jQuery.validator.format("Please enter {0} words or less."));
 
 	jQuery.validator.addMethod("minWords", function(value, element, params) {

--- a/test/methods.js
+++ b/test/methods.js
@@ -527,8 +527,15 @@ test("maxWords", function() {
 	ok( method("hello", 2), "plain text, valid" );
 	ok( method("<b>world</b>", 2), "html, valid" );
 	ok( method("world <br/>", 2), "html, valid" );
-	ok( !method("hello worlds", 2), "plain text, invalid" );
-	ok( !method("<b>hello</b> world", 2), "html, invalid" );
+	
+	// Updating unit tests to support correct definition of maxWords (implied
+	// by the default error message). See #284
+	ok( method("hello worlds", 2), "plain text, valid" );
+	ok( method("<b>hello</b> world", 2), "html, valid" );
+	ok( method("hello world <br/>", 2), "html, valid" );
+	
+	ok( !method("hello world bar", 2), "plain text, invalid" );
+	ok( !method("<b>hello</b> world bar", 2), "html, invalid" );
 });
 
 test("pattern", function() {


### PR DESCRIPTION
Fix for #285 - "maxWords" validation method is off by one.
