### PR TITLE
aliasing old method on addMethod

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -911,6 +911,9 @@ $.extend($.validator, {
 
 	// http://docs.jquery.com/Plugins/Validation/Validator/addMethod
 	addMethod: function(name, method, message) {
+		if($.validator.methods[name]) {
+	            $.validator.methods["old_" + name] = $.validator.methods[name];
+	        }
 		$.validator.methods[name] = method;
 		$.validator.messages[name] = message != undefined ? message : $.validator.messages[name];
 		if (method.length < 3) {


### PR DESCRIPTION
When overriding a method, addMethod keeps the old method as old_<methodname>. This makes the old method still available when needed. This is useful when the overriding method only wants to add some more checks and then call the existing one
