### PR TITLE
Issue #287 : change 'accept' to support HTML standard accept attribute

### DIFF
--- a/demo/file_input.html
+++ b/demo/file_input.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>jQuery validation plug-in - comment form example</title>
+
+<link rel="stylesheet" type="text/css" media="screen" href="css/screen.css" />
+
+<script src="../lib/jquery.js" type="text/javascript"></script>
+<script src="../jquery.validate.js" type="text/javascript"></script>
+
+<script type="text/javascript">
+$(document).ready(function() {
+	$("#fileForm").validate();
+});
+</script>
+
+<style type="text/css">
+#fileForm { width: 500px; }
+#fileForm label { width: 250px; }
+#fileForm label.error, #fileForm input.submit { margin-left: 253px; }
+</style>
+
+</head>
+<body>
+
+<form class="cmxform" id="fileForm" method="post" action="">
+	<fieldset>
+		<legend>Select the indicated type of files?</legend>
+		<p>
+			<label for="file1">Select a plain text file (e.g. *.txt)</label>
+			<input type="file" id="file1" name="name" class="required" accept="text/plain" />
+		</p>
+		<p>
+			<label for="file2">Select any image file</label>
+			<input type="file" id="file2" name="file2" class="required" accept="image/*"/>
+		</p>
+		<p>
+			<label for="file3">Select either a PDF or a EPS file</label>
+			<input type="file" id="file3" name="file3" class="required" accept="image/x-eps,application/pdf"/>
+		</p>
+		<p>
+			<label for="file4">Select any audio or image file</label>
+			<input type="file" id="file4" name="file4" class="required" accept="image/*,audio/*"/>
+		</p>
+		<p>
+			<label for="file5">Enter the name of either a PDF or EPS file</label>
+			<input id="file5" name="file5" class="required" accept="pdf,eps"/>
+		</p>
+		<p>
+			<input class="submit" type="submit" value="Submit"/>
+		</p>
+	</fieldset>
+</form>
+
+</body>
+</html>

--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1084,8 +1084,17 @@ $.extend($.validator, {
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/accept
 		accept: function(value, element, param) {
-			param = typeof param == "string" ? param.replace(/,/g, '|') : "png|jpe?g|gif";
-			return this.optional(element) || value.match(new RegExp(".(" + param + ")$", "i"));
+		        var re_pre = ".(";
+			var re_post = ")$";
+		        var default_param = "png|jpe?g|gif";
+		        if ( $(element).attr("type") == "file" ) {
+			    re_pre = "(";
+			    default_param = "image/*";
+			    value = element.files[0].type
+			    re_post = ")";
+			}
+			param = typeof param == "string" ? param.replace(/,/g, '|') : default_param;
+			return this.optional(element) || value.match(new RegExp(re_pre + param + re_post, "i"));
 		},
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/equalTo


### PR DESCRIPTION
This change modifies the 'accept' attribute behavior to agree with the HTML standard.

Specifically, if the 'accept' attribute is used with a file input field, then it should have the format matching a MIME type rather than a file extension.

In the event the 'accept' attribute is being used on a NON-flle input field, then the existing validation behavior is preserved. This is really for 2 reasons:
- While the HTML standard specifies the 'accept' attribute is to only be used with file input fields, there was nothing in the existing jquery-validation plugin which prevented it from being used on text input fields.
- Also the MIME type property which is being checked on the client side is only available for file input fields. So it seemed reasonable to leave the existing behavior.

With this change I've include a demo, and all the 'accept' unit tests are passing.
