### PR TITLE
Issue 26: Adding a test that calling .element in jQuery validate doesn't reset the status of other elements

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1191,12 +1191,12 @@ test( "Ignores other elements when validating a single element", function() {
 	expect( 5 );
 	
 	var form = $( "#signupForm" );
-    var validate = form.validate({
-        rules:{
-            "user": "required",
+	var validate = form.validate({
+		rules:{
+			"user": "required",
 			"password": "required"
-        }
-    });
+		}
+	});
 	
 	ok(! validate.form(), "form should be initially invalid" );
 	


### PR DESCRIPTION
It appears that issue 26 has largely been fixed, but having a test for it seems worthwhile.
