### PR TITLE
Remote validation on select with multiple=true

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -500,7 +500,20 @@ $.extend($.validator, {
 			for (var method in rules ) {
 				var rule = { method: method, parameters: rules[method] };
 				try {
-					var result = $.validator.methods[method].call( this, element.value.replace(/\r/g, ""), element, rule.parameters );
+					var elementValue = element.value.replace(/\r/g, "");
+					if (element.tagName.toLowerCase() == "select" && element.getAttribute("multiple")) {
+						var elementValueArray = [];
+						for (var i = 0; i < element.options.length; i++) {
+							var option = element.options[i];
+							if (option.selected) {
+								elementValueArray.push(option.value.replace(/\r/g, ""));
+							}
+						}
+
+						elementValue = elementValueArray.join(",");
+					}
+					
+					var result = $.validator.methods[method].call( this, elementValue, element, rule.parameters );
 
 					// if a method indicates that the field is optional and therefore valid,
 					// don't mark it as valid when there are no other rules


### PR DESCRIPTION
I found a bug with a multi select and the remote validation.  Basically only the first selected value was being set to the data("previousValue") because that was all the element.value was returning.  I added a check to see if it is a select and if the multiple attribute is set, if it is, it simply collects all of the selected values and joins them on a comma and passes that in as the value to the validation method.  I am currently running this code and have not seen any issues with it.

Thanks,
Doug
