### PR TITLE
Fixes for Multiple Error Messages when errorClass has more than one class names

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -490,7 +490,8 @@ $.extend($.validator, {
 		},
 
 		errors: function() {
-			return $( this.settings.errorElement + "." + this.settings.errorClass, this.errorContext );
+			// use the first class name in the errorClass as selector
+			return $( this.settings.errorElement + "." + this.settings.errorClass.split(" ")[0], this.errorContext );
 		},
 
 		reset: function() {


### PR DESCRIPTION
Fix a bug where when the errorClass option is provided with multiple class names, every time it triggers validation it will keep showing multiple error messages instead of updating the existing error messages. This is because the errors() method assume the errorClass option is only one class name.
