### PR TITLE
Fix for #284

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -20,7 +20,7 @@
 		.replace(/[0-9.(),;:!?%#$'"_+=\/-]*/g,'');
 	}
 	jQuery.validator.addMethod("maxWords", function(value, element, params) {
-	    return this.optional(element) || stripHtml(value).match(/\b\w+\b/g).length < params;
+	    return this.optional(element) || stripHtml(value).match(/\b\w+\b/g).length <= params;
 	}, jQuery.validator.format("Please enter {0} words or less."));
 
 	jQuery.validator.addMethod("minWords", function(value, element, params) {

--- a/test/index.html
+++ b/test/index.html
@@ -276,6 +276,10 @@
 		<form id="ccform" method="get" action="">
 			<input id="cardnumber" name="cardnumber" />
 		</form>
+
+		<form id="maxWordsForm">
+			<input id="maxWordsTest" name="maxWordsTest" type="text" />
+		</form>
 	</div>
 
 </body>

--- a/test/methods.js
+++ b/test/methods.js
@@ -527,8 +527,23 @@ test("maxWords", function() {
 	ok( method("hello", 2), "plain text, valid" );
 	ok( method("<b>world</b>", 2), "html, valid" );
 	ok( method("world <br/>", 2), "html, valid" );
-	ok( !method("hello worlds", 2), "plain text, invalid" );
-	ok( !method("<b>hello</b> world", 2), "html, invalid" );
+	ok( method("hello worlds", 2), "plain text, invalid" );
+	ok( method("<b>hello</b> world", 2), "html, invalid" );
+	ok( !method("hello my world", 2), "plain text, invalid" );
+	ok( !method("<b>hello</b> my world", 2), "html, invalid" );
+});
+
+test("maxWords form correct count", function() {
+	var f = $('#maxWordsForm');
+	f.validate({
+		rules: {
+			maxWordsTest: {
+				maxWords: 2
+			}
+		}
+	});
+	f.find("input").val('one two');
+	ok( f.valid(), "correct number" );
 });
 
 test("pattern", function() {


### PR DESCRIPTION
This is a change for #284. The original submitter is correct, there is either an issue with the maxWords error formatting string, or the logic isn't correct.

When I read "maxWords" I consider the maximum value to be inclusive. The format string matches that by saying "please enter {{maxWords}} or less." Thus indicating the logic is wrong.
