### PR TITLE
fix: .optional always evaluated to truth

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -724,7 +724,7 @@ $.extend($.validator, {
 		},
 
 		optional: function(element) {
-			return !$.validator.methods.required.call(this, $.trim(element.value), element) && "dependency-mismatch";
+			return !$.validator.methods.required.call(this, $.trim(element.value), element);
 		},
 
 		startRequest: function(element) {


### PR DESCRIPTION
it's probably a typo. Trailing "&& "dependency-mismatch" makes "optional" method always to evaluate to truth. Because of this, "onfocusout" handler does not check empty fields.
