### PR TITLE
fix optional method

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -763,7 +763,7 @@ $.extend($.validator, {
 
 		optional: function(element) {
 			var val = this.elementValue(element);
-			return !$.validator.methods.required.call(this, val, element) && "dependency-mismatch";
+			return !$(element).rules().required && !$.validator.methods.required.call(this, val, element) && "dependency-mismatch";
 		},
 
 		startRequest: function(element) {

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,7 +1,7 @@
 (function($) {
 
 function methodTest( methodName ) {
-	var v = jQuery("#form").validate();
+	var v = jQuery("#testForm1").validate();
 	var method = $.validator.methods[methodName];
 	var element = $("#firstname")[0];
 	return function(value, param) {


### PR DESCRIPTION
Hi

I'm following up on pull request #350. The patch in pull request was wrong, so I created another one.

It fixes the problem that emty field which has required rule is not checked on focusout. Here is the test case:

https://github.com/jzaefferer/jquery-validation/pull/350#issuecomment-4920430

So how optional method works with this patch. First it checks that element has required rule, if it has, element is not optional. Then if element does not have required rule, checked if it's empty (as it was checked before). This fixes the problem described (test case as http://jsfiddle.net/kPfja/).

But it reveal that there is a bug in test: validator created on #form, but element from #testForm1 is used in tests. So element.form references form on which validator was not instantiated. Until $(element).rules() was not used this bug was not visible, but with this method bug proved to be exist (tests fails with an error that $.data(element.form, 'validator') returned undefined value).

So I fixed tests as well.
