### PR TITLE
Fix for issue# 301 - attribute is accessed with native JS resulting in clearer logic

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -837,7 +837,6 @@ $.extend($.validator, {
 
 		for (var method in $.validator.methods) {
 			var value;
-			// If .prop exists (jQuery >= 1.6), use it to get true/false for required
 			if (method === 'required') {
 				value = $element.get(0).getAttribute(method);
 				// Some browsers return an empty string for the reqired attribute


### PR DESCRIPTION
Sorry for the PR spam, I think this one nails it: it makes sense (as suggested on PR#349 comments) to just use the native JS .getAttribute() call rather than test jQuery for .prop() etc. The result is far less logic (therefore cleaner code) in that method.

I've tested this with IE7-9 and FF3.6, using "required", "true" and "" for the required attribute value.

I guess this PR replaces PR#349?
