### PR TITLE
Removed incorrect false check on required attribute

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -845,8 +845,6 @@ $.extend($.validator, {
 				// and non-HTML5 browsers might have required="" markup
 				if (value === "") {
 					value = true;
-				} else if (value === "false") {
-					value = false;
 				}
 				// force non-HTML5 browsers to return bool
 				value = !!value;


### PR DESCRIPTION
Per Paul's comment on #355 and my previews PR #356, required="false" should still trigger required="true" based on HTML spec for properties. I've removed that forced conversion.
