### PR TITLE
Add "input:not([type])" to validateDelegate selector. Fixes #217.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -323,7 +323,7 @@ $.extend($.validator, {
 				}
 			}
 			$(this.currentForm)
-				.validateDelegate("[type='text'], [type='password'], [type='file'], select, textarea, " +
+				.validateDelegate("input:not([type]), [type='text'], [type='password'], [type='file'], select, textarea, " +
 					"[type='number'], [type='search'] ,[type='tel'], [type='url'], " +
 					"[type='email'], [type='datetime'], [type='date'], [type='month'], " +
 					"[type='week'], [type='time'], [type='datetime-local'], " +


### PR DESCRIPTION
Tested on FF 11, Safari 5.1.5, Chrome 18 (all of which suffered from this bug) under OS X 10.6.8. It appears to fix the bug on all three.
