### PR TITLE
Adds support for checkbox and radio values

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -510,19 +510,13 @@ $.extend($.validator, {
 		},
 
 		elementValue: function( element ) {
-<<<<<<< HEAD
 			var type = $(element).attr('type'),
 				val = $(element).val();
 
 			if( type === 'radio' || type === 'checkbox' ) {
 				return $('input[name="' + $(element).attr('name') + '"]:checked').val();
 			}
-=======
-			if( $(element).attr('type') === 'radio') {
-				return $('input:radio[name="' + $(element).attr('name') + '"]:checked').val();
-			}
-			var val = $(element).val();
->>>>>>> 6edc0d0... Value for radio buttons
+
 			if( typeof val === 'string' ) {
 				return val.replace(/\r/g, "");
 			}


### PR DESCRIPTION
When sending values for checkboxes and radio buttons, the value used to be the first element in the group. This modifications makes the checked element's value the value of the group. Fixes #363
