### PR TITLE
Minor fix for 'alphanumeric' validator message

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -39,7 +39,7 @@ jQuery.validator.addMethod("letterswithbasicpunc", function(value, element) {
 
 jQuery.validator.addMethod("alphanumeric", function(value, element) {
 	return this.optional(element) || /^\w+$/i.test(value);
-}, "Letters, numbers, spaces or underscores only please");
+}, "Letters, numbers, and underscores only please");
 
 jQuery.validator.addMethod("lettersonly", function(value, element) {
 	return this.optional(element) || /^[a-z]+$/i.test(value);


### PR DESCRIPTION
This validator uses a pattern of `/^\w+$/` and had a message saying "Letters, numbers, spaces or underscores only please", however, the `\w` metacharacter doesn't include spaces (it's equivalent to `[a-zA-Z0-9_]`), so I amended the message to match reality.
