### PR TITLE
Added comma replacement for min/max methods and updated tests. Fixes #379

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1067,12 +1067,12 @@ $.extend($.validator, {
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/min
 		min: function( value, element, param ) {
-			return this.optional(element) || value >= param;
+			return this.optional(element) || value.replace(/\,/g,'') >= param;
 		},
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/max
 		max: function( value, element, param ) {
-			return this.optional(element) || value <= param;
+			return this.optional(element) || value.replace(/\,/g,'') <= param;
 		},
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/range

--- a/test/index.html
+++ b/test/index.html
@@ -178,6 +178,7 @@
 			<input type="text" name="action" value="0" id="value1"/>
 			<input type="text" name="text2" value="10" id="value2"/>
 			<input type="text" name="text2" value="1000" id="value3"/>
+			<input type="text" name="text2" value="1,000" id="value4"/>
 
 			<input type="radio" name="radio1" id="radio1"/>
 			<input type="radio" name="radio1" id="radio1a"/>

--- a/test/methods.js
+++ b/test/methods.js
@@ -304,20 +304,22 @@ test("min", function() {
 	var v = jQuery("#form").validate();
 	var method = $.validator.methods.min,
 		param = 8,
-		e = $('#value1, #value2, #value3');
+		e = $('#value1, #value2, #value3, #value4');
 	ok(!method.call( v, e[0].value, e[0], param), "Invalid text input" );
 	ok( method.call( v, e[1].value, e[1], param), "Valid text input" );
 	ok( method.call( v, e[2].value, e[2], param), "Valid text input" );
+	ok( method.call( v, e[3].value, e[3], param), "Valid text input" );
 });
 
 test("max", function() {
 	var v = jQuery("#form").validate();
 	var method = $.validator.methods.max,
 		param = 12,
-		e = $('#value1, #value2, #value3');
+		e = $('#value1, #value2, #value3, #value4');
 	ok( method.call( v, e[0].value, e[0], param), "Valid text input" );
 	ok( method.call( v, e[1].value, e[1], param), "Valid text input" );
 	ok(!method.call( v, e[2].value, e[2], param), "Invalid text input" );
+	ok( !method.call( v, e[3].value, e[3], param), "Invalid text input" );
 });
 
 test("range", function() {


### PR DESCRIPTION
It makes sense that if we accept numbers with US comma separators for numbers that we also accept them for min/max.
