### PR TITLE
Changed lastElement to lastActive in keyup. Fixes #244

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -234,7 +234,9 @@ $.extend($.validator, {
 			}
 		},
 		onkeyup: function(element, event) {
-			if ( element.name in this.submitted || element === this.lastActive ) {
+			if ( event.which == 9 && this.elementValue(element) === '' ) {
+				return;
+			} else if ( element.name in this.submitted || element === this.lastActive ) {
 				this.element(element);
 			}
 		},


### PR DESCRIPTION
It seems the keyup method was using a different variable to keep track of the last active element. I switched it to the `lastActive` element which is set in onfocus, which makes more sense and fixes the issue.
