### PR TITLE
Moved to jQuery [name] lookup for findByName. Fixes #82

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -732,11 +732,7 @@ $.extend($.validator, {
 		},
 
 		findByName: function( name ) {
-			// select by name and filter by form for performance over form.find("[name=...]")
-			var form = this.currentForm;
-			return $(document.getElementsByName(name)).map(function(index, element) {
-				return element.form === form && element.name === name && element  || null;
-			});
+			return $(this.currentForm).find('[name="' + name + '"]');
 		},
 
 		getLength: function(value, element) {


### PR DESCRIPTION
This is intended as a review. 

According to #82 and #275, there are issues with the old `getElementsByName` that was intended to provide a performance increase. This will probably be slower but could fix some of these issues and provide more flexibility.
