### PR TITLE
Changed behavior of error labels when type is radio. Fixes #98

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -693,7 +693,12 @@ $.extend($.validator, {
 					if ( this.settings.errorPlacement ) {
 						this.settings.errorPlacement(label, $(element) );
 					} else {
-					label.insertAfter(element);
+						if ( $(element).is(':radio') ) {
+							var radioElements = this.findByName( $(element).attr('name') );
+							label.insertAfter(radioElements.filter(':last'));
+						} else {
+							label.insertAfter(element);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This is intended for review.

The current `showLabel` behavior doesn't make sense for a group of radio buttons. The label by default goes right after the first button, rather than after the whole group.

This PR puts the label after the end of the group by default for radio buttons.
