### PR TITLE
Clear previous values stored when resetForm is called. Fixes #312

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -410,7 +410,7 @@ $.extend($.validator, {
 			this.lastElement = null;
 			this.prepareForm();
 			this.hideErrors();
-			this.elements().removeClass( this.settings.errorClass );
+			this.elements().removeClass( this.settings.errorClass ).removeData( "previousValue" );
 		},
 
 		numberOfInvalids: function() {

--- a/test/methods.js
+++ b/test/methods.js
@@ -495,8 +495,9 @@ asyncTest("remote radio correct value sent", function() {
 	v.element(e);
 });
 
-asyncTest("remote correct number of invalids", function() {
-	expect(4);
+asyncTest("remote reset clear old value", function() {
+	expect(1);
+
 	var e = $("#username");
 	var v = $("#userForm").validate({
 		rules: {
@@ -504,43 +505,36 @@ asyncTest("remote correct number of invalids", function() {
 				required: true,
 				remote: {
 					url: "echo.php",
-					dataType: 'json',
 					dataFilter: function(data) {
-						var json = JSON.parse(data);
-						if(json.username == 'asdf') {
-							return "\"asdf is already taken\"";
-						}
 						return true;
 					}
 				}
 			}
-		},
-		messages: {
-			username: {
-				required: "Please"
-			}
-		},
-		submitHandler: function() {
-			ok( false, "submitHandler may never be called when validating only elements");
 		}
 	});
 	$(document).ajaxStop(function() {
-		$(document).unbind("ajaxStop");
-		equal( 1, v.numberOfInvalids(), "There must be one error" );
+		var waitTimeout;
 
-		e.val("max");
+		$(document).unbind("ajaxStop");
+
 
 		$(document).ajaxStop(function() {
-			equal( 0, v.numberOfInvalids(), "There must not be any errors" );
+			clearTimeout(waitTimeout);
+			ok( true, "Remote request sent to server" );
 			start();
 		});
 
+
+		v.resetForm();
+		e.val("asdf");
+		waitTimeout = setTimeout(function() {
+			ok( false, "Remote server did not get request");
+			start();
+		}, 200);
 		v.element(e);
 	});
-	strictEqual( v.element(e), false, "invalid element, nothing entered yet" );
 	e.val("asdf");
-  strictEqual( v.numberOfInvalids(), 1, "still invalid, because remote validation must block until it returns; dependency-mismatch considered as valid though" );
-  v.element(e);
+	v.element(e);
 });
 
 module("additional methods");

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,8 @@ $.mockjax({
 	url: "echo.php",
 	response: function(data) {
 		this.responseText = JSON.stringify(data.data);
-	}
+	},
+	responseTime: 100
 });
 
 module("validator");


### PR DESCRIPTION
This will clear any previous value data that had been set on an element when resetForm is called.
