### PR TITLE
Fixed regex for time additional method. Fixes #131

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -158,7 +158,7 @@ jQuery.validator.addMethod("dateNL", function(value, element) {
 }, "Vul hier een geldige datum in.");
 
 jQuery.validator.addMethod("time", function(value, element) {
-	return this.optional(element) || /^([01]\d|2[0-3])(:[0-5]\d){0,2}$/.test(value);
+	return this.optional(element) || /^([0-1][0-9]|2[0-3]):([0-5][0-9])$/.test(value);
 }, "Please enter a valid time, between 00:00 and 23:59");
 jQuery.validator.addMethod("time12h", function(value, element) {
 	return this.optional(element) || /^((0?[1-9]|1[012])(:[0-5]\d){0,2}(\ [AP]M))$/i.test(value);

--- a/test/methods.js
+++ b/test/methods.js
@@ -563,6 +563,7 @@ test("time", function() {
 	var method = methodTest("time");
 	ok( method("00:00"), "Valid time, lower bound" );
 	ok( method("23:59"), "Valid time, upper bound" );
+	ok( !method("12"), "Invalid time" );
 	ok( !method("00:60"), "Invalid time" );
 	ok( !method("24:60"), "Invalid time" );
 	ok( !method("24:00"), "Invalid time" );


### PR DESCRIPTION
The regex for the "time" additional method was just messed up. This one makes the error format text match the regex. For example, the user must enter a value from 00:00 to 23:59, using 0 fill for hours < 10.
