### PR TITLE
Add support for custom messages in HTML5 data attributes

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -581,6 +581,12 @@ $.extend($.validator, {
 			return meta && meta.messages && meta.messages[method];
 		},
 
+		// return the custom message for the given element and validation method
+		// specified in the element's HTML5 data attribute
+		customDataMessage: function(element, method) {
+			return $(element).data('msg-' + method.toLowerCase()) || (element.attributes && $(element).attr('data-msg-' + method.toLowerCase()));
+		},
+
 		// return the custom message for the given element name and validation method
 		customMessage: function( name, method ) {
 			var m = this.settings.messages[name];
@@ -600,6 +606,7 @@ $.extend($.validator, {
 		defaultMessage: function( element, method) {
 			return this.findDefined(
 				this.customMessage( element.name, method ),
+				this.customDataMessage( element, method ),
 				this.customMetaMessage( element, method ),
 				// title is never undefined, so handle empty string as undefined
 				!this.settings.ignoreTitle && element.title || undefined,

--- a/test/index.html
+++ b/test/index.html
@@ -154,6 +154,10 @@
 			<input name="testForm12text" id="testForm12text" class="{required:true}" />
 		</form>
 
+		<form id="dataMessages">
+			<input name="dataMessagesName" id="dataMessagesName" class="required" data-msg-required="You must enter a value here" />
+		</form>
+
 		<div id="simplecontainer">
 			<h3></h3>
 		</div>

--- a/test/test.js
+++ b/test/test.js
@@ -1252,3 +1252,15 @@ test("ignore hidden elements at start", function(){
     $('#userForm [name=username]').show();
     ok(! validate.form(), "form should be invalid when required element is visible");
 });
+
+test("Specify error messages through data attributes", function() {
+	var form = $('#dataMessages');
+	var name = $('#dataMessagesName');
+	var v = form.validate();
+
+	form.get(0).reset();
+	name.valid();
+
+	var label = $('#dataMessages label');
+	equal( label.text(), "You must enter a value here", "Correct error label" );
+});


### PR DESCRIPTION
See original PR #421. This adds a test and additional support for jQuery < 1.4.2 which did not support grabbing attribute values with the `data` function.
