### PR TITLE
fix for issue #430

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -669,13 +669,14 @@ $.extend($.validator, {
 		},
 
 		showLabel: function(element, message) {
-			var label = this.errorsFor( element );
+			var label = this.errorsFor( element ),
+				okToReplace = label.attr("generated") || label.hasClass(this.settings.errorClass);
 			if ( label.length ) {
 				// refresh error/success class
 				label.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
 
 				// check if we have a generated label, replace the message then
-				if ( label.attr("generated") || label.hasClass(this.settings.errorClass) ) {
+				if ( okToReplace ) {
 					label.html(message);
 				}
 			} else {

--- a/test/index.html
+++ b/test/index.html
@@ -291,6 +291,11 @@
 			<input class="productInfo" name="color">
 			<input class="productInfo" type="checkbox" name="discount" />
 		</form>
+		
+		<form id="updateLabel">
+			<input class="required" name="updateLabelInput" id="updateLabelInput" data-msg-required="You must enter a value here" />
+			<label id="targetLabel" class="error" for="updateLabelInput">Some server-side error</label>
+		</form>
 
 	</div>
 

--- a/test/test.js
+++ b/test/test.js
@@ -1280,3 +1280,25 @@ test("Specify error messages through data attributes", function() {
 	var label = $('#dataMessages label');
 	equal( label.text(), "You must enter a value here", "Correct error label" );
 });
+
+
+test("Updates pre-existing label if has error class", function() {
+	var form = $('#updateLabel'),
+		input = $('#updateLabelInput'),
+		label = $('#targetLabel'),
+		v = form.validate(),
+		labelsBefore = form.find('label').length,
+		labelsAfter;
+
+	input.val('');
+	input.valid();
+	labelsAfter = form.find('label').length;
+
+	// label was updated
+	equal( label.text(), input.attr('data-msg-required') );
+	// new label wasn't created
+	equal( labelsBefore, labelsAfter );
+});
+
+
+


### PR DESCRIPTION
Firstly, apologies if I've done something wrong here, my first effort at contributing a fix. I _think_ I've committed against an issue, though I may have done it completely wrong!

This covers the case where the the form has failed server-side validation and so the form is sent back to the user with server-generated error labels. Currently the validation plugin will not update these labels if new user input causes client-side validation to fail. This commit fixes that.

I made the assumption that any existing label which already has the errorClass assigned is safe to update with a new message, which i believe is a safe assumption (why would any label other than a validation error label, already have the errorClass assigned?)

Thanks,
Nick
