### PR TITLE
Initial release of better token support

### DIFF
--- a/demo/ReplaceTokens test.html
+++ b/demo/ReplaceTokens test.html
@@ -1,0 +1,138 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Demonstrates improved tokens in error messages.</title>
+   <script src="../lib/jquery.js" type="text/javascript"></script>
+   <script src="../jquery.validate.js" type="text/javascript"></script>
+   <script src="../jquery.validate.unobtrusive.js" type="text/javascript"></script>
+   <style type="text/css">
+      .error
+      {
+         color : Red;
+      }
+      .errorlabel
+      {
+         font-weight : bold;
+         text-transform : capitalize;
+      }
+      .valid
+      {
+      }
+   </style>
+</head>
+<body>
+   <script type="text/javascript">
+   $(document).ready(
+      function(){ $("#Form1").validate({onkeyup : false, debug : true});
+         $("#TextBox1").rules("add",
+         {
+
+            required: true,
+            messages:
+            {
+               required: "<span class='errorlabel'>{LABEL}</span> is required."
+            }
+
+         });
+
+         $("#TextBox2").rules("add",
+         {
+
+            minlength: 4,
+            messages:
+            {
+               minlength: "<span class='errorlabel'>{LABEL}</span> must be {MIN} characters or higher. You entered {LENGTH} which is {DIFF} short."
+            }
+
+         });
+         $("#TextBox3").rules("add",
+         {
+
+            maxlength: 10,
+            messages:
+            {
+               maxlength: "<span class='errorlabel'>{LABEL}</span> must be be no more than {MAX} characters. You entered {LENGTH} which is {DIFF} too much."
+            }
+
+         });
+
+         $("#TextBox4").rules("add",
+         {
+
+            rangelength: [4,10],
+            messages:
+            {
+               rangelength: "<span class='errorlabel'>{LABEL}</span> must be between {MIN} and {MAX} characters. You entered {LENGTH} which is {DIFF} too little or much."
+            }
+
+         });
+         $("#TextBox5").rules("add",
+         {
+
+            min: 4,
+            messages:
+            {
+               min: "<span class='errorlabel'>{LABEL}</span> must be {MIN} or higher. You entered {VALUE}."
+            }
+
+         });
+         $("#TextBox6").rules("add",
+         {
+
+            max: 10,
+            messages:
+            {
+               max: "<span class='errorlabel'>{LABEL}</span> must be be no more than {MAX}. You entered {VALUE}."
+            }
+
+         });
+
+         $("#TextBox7").rules("add",
+         {
+
+            range: [4,10],
+            messages:
+            {
+               range: "<span class='errorlabel'>{LABEL}</span> must be between {MIN} and {MAX}. You entered {VALUE}."
+            }
+
+         });
+         $("#TextBox8").rules("add",
+         {
+
+            url: true,
+            messages:
+            {
+               url: "<span class='errorlabel'>{LABEL}</span> must be a URL. You entered \"{VALUE}\"."
+            }
+
+         });
+
+
+      }
+   );
+   </script>
+   <p>Demonstrates validation error messages containing tokens using the new replaceToken code.</p>
+   <p>Now each validation method can have a companion method that is passed the error message string.
+   It replaces tokens within that string and returns the updated message.</p>
+   <p>Tokens can be textual and therefore meaningful (like {VALUE}) as compared to the existing model ({0}).</p>
+   <p>The default token replacement method supports the numeric tokens of the past, and adds these: 
+   {LABEL} and {VALUE}. {LABEL} extracts the label associated with the element, either from the data-msglabel attribute
+   on the element or from a &lt;label for= &gt; tag. {VALUE} is the actual data entered.</p>
+   <p>Validators with minimum and maximum rules have additional tokens: {MIN} and {MAX}.
+   The length validators also have {LENGTH} and {DIFF}. {DIFF} is the number the user has exceeded the min or max.</p><br />
+   <!-- REMINDER: Unobtrustive doesn't use the labels 'minlength', 'maxlength', 'rangelength', 'min', and 'max'. You must use 'length' and 'range' instead. -->
+   <form action="" method="post" id="Form1" >
+      <label for="TextBox1" >Required: </label><input type="text" id="TextBox1" name="TextBox1" /><br />
+      <label for="TextBox2" >Minlength: </label><input type="text" id="TextBox2" name="TextBox2" data-msglabel="MINLENGTH" /><br />
+      <label for="TextBox3" >Maxlength: </label><input type="text" id="TextBox3" name="TextBox3" /><br />
+      <label for="TextBox4" >Rangelength: </label><input type="text" id="TextBox4" name="TextBox4" /><br />
+      <label for="TextBox5" >Min: </label><input type="text" id="TextBox5" name="TextBox5" /><br />
+      <label for="TextBox6" >Max: </label><input type="text" id="TextBox6" name="TextBox6" /><br />
+      <label for="TextBox7" >Range: </label><input type="text" id="TextBox7" name="TextBox7" /><br />
+      <label for="TextBox8" >Url: </label><input type="text" id="TextBox8" name="TextBox8" /><br />
+      <input type="submit" id="Button1" />
+   </form>
+
+</body>
+</html>

--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -11,6 +11,13 @@
  *   http://www.gnu.org/licenses/gpl.html
  */
 
+ /*
+ ALERT: THIS FILE HAS BEEN CUSTOMIZED BASED ON v1.9.0-69-g92cafa8.
+ IT REPLACES THE $.validator.formatAndAdd FUNCTION
+ AND ADDS NEW PROPERTIES TO THE PROTOTYPE OF $.validator.
+ THE NEW CODE SUPPORTS A NEW WAY TO HANDLE TOKENS IN THE
+ ERROR MESSAGE.
+ */
 (function($) {
 
 $.extend($.fn, {
@@ -616,13 +623,24 @@ $.extend($.validator, {
 		},
 
 		formatAndAdd: function( element, rule ) {
-			var message = this.defaultMessage( element, rule.method ),
+			var message = this.defaultMessage( element, rule.method );
+/*
 				theregex = /\$?\{(\d+)\}/g;
+*/
 			if ( typeof message === "function" ) {
 				message = message.call(this, rule.parameters, element);
-			} else if (theregex.test(message)) {
+			} 
+/* REPLACED BY replaceTokens system. This is built into defaultTokenReplacer         
+         else if (theregex.test(message)) {
 				message = $.validator.format(message.replace(theregex, '{$1}'), rule.parameters);
 			}
+*/
+         var rt = $.validator.replaceTokens[rule.method];
+         if (!rt)
+         {
+            rt = $.validator.defaultTokenReplacer;
+         }
+         message = rt.call($.validator, message, element, rule.parameters, $(element).val());
 			this.errorList.push({
 				message: message,
 				element: element
@@ -975,12 +993,15 @@ $.extend($.validator, {
 	},
 
 	// http://docs.jquery.com/Plugins/Validation/Validator/addMethod
-	addMethod: function(name, method, message) {
+	addMethod: function(name, method, message, replaceTokenMethod) {
 		$.validator.methods[name] = method;
 		$.validator.messages[name] = message !== undefined ? message : $.validator.messages[name];
 		if (method.length < 3) {
 			$.validator.addClassRules(name, $.validator.normalizeRule(name));
 		}
+      if (!replaceTokenMethod)
+         replaceTokenMethod = $.validator.defaultTokenReplacer;
+      $.validator.replaceTokens[name] = replaceTokenMethod;
 	},
 
 	methods: {
@@ -1168,6 +1189,172 @@ $.extend($.validator, {
 			return value === target.val();
 		}
 
+	},
+
+//--- TOKEN REPLACEMENT SUPPORT ------------------------------------
+   // matches tokens with only digits. They retrieve values from the param object 
+   // based on the physical order of properties defined. 
+   // Replaces the {VALUE} token with the value parameter's string.
+   // Replaces the {LABEL} token with the label associated with the element.
+   // If the value parameter is not already a string, it will be converted with toString().
+   // If you need better formatting, implement your own replacement of the {VALUE} token.
+   defaultTokenReplacer : function(message, element, param, value) {
+		   var regex = /\$?\{(\d+)\}/g;  
+			if (regex.test(message)) {
+				message = $.validator.format(message.replace(regex, '{$1}'), param);
+         }
+         if (value == null)
+            value = "";
+         message = this.tokenReplacer(message, "VALUE", value.toString());   // {VALUE} token
+         var lbl = this.elementLabel(element) || "*** Add the data-msglabel attribute to id " + element.id + ". ***";
+         message = this.tokenReplacer(message, "LABEL", lbl);   // {LABEL} token
+			return message;
+		},
+
+// Utility to replace tokens in the message. 
+// A token is letters enclosed in brackets like {ABC}
+// however, you don't pass in the brackets to the tokentxt parameter.
+// tokentxt is just the letters. Uses a case insensitive match.
+// rpl in the string that replaces the token. 
+// Returns the modified message. 
+   tokenReplacer : function(message, tokentxt, rpl) {
+         var re = new RegExp("\\{" + tokentxt + "\\}", "ig");
+         return message.replace(re, rpl.toString());
+      },
+
+// Utility used by replacer functions that provide {MIN} and/or {MAX}
+// tokens. It also supports {LENGTH} and {DIFF} tokens.
+   // {MIN} - The value from min identifying the minimum length
+   // {MAX} - The value from max identifying the maximum length
+   // {LENGTH} - The current length
+   // {DIFF} - The difference between the length an the minimum or maximum,
+   // but only works when min or max are integers.
+   minMaxReplacer :function(message, min, max, length) {
+         if (min != null)
+			   message = this.tokenReplacer(message, "MIN", min);
+         if (max != null)
+			   message = this.tokenReplacer(message, "MAX", max);
+         if (length != null)
+         {
+			   message = this.tokenReplacer(message, "LENGTH", length);
+         // {DIFF} is only supposed to handle integer min/max.
+         // This code runs even if min/max are null or not integers.
+         // It assumes the DIFF token isn't used in that case, but if it is, the result will be meaningful
+            if (typeof min !== "number")
+               min = 0;
+            if (typeof max !== "number")
+               max = 99999999;
+            var diff = Math.max(length - max, min - length);
+            message = this.tokenReplacer(message, "DIFF", diff);
+         }
+         return message;
+		},
+
+   /* 
+   Locates a string that can be displayed as the label for the element
+   within a message.
+   The element can host this label in its data-msglabel attribute or
+   there is another with a for= attribute specifying this element whose
+   HTML is the label. If both are present, data-label overrides
+   the for= attribute. 
+   NOTE: The value "data-msglabel" was chosen over "data-label" to avoid
+   conflicts with other systems.
+      element (DOM Element) - Accepts null.
+   Returns the label string or null if not located.
+   The result will not contain HTML tags found in the source.
+   */
+   elementLabel:  function (element) {
+         if (!element)
+         {
+            return null;
+         }
+         var t = element.getAttribute("data-msglabel");
+         // Alternative: t = $(element).data('msglabel') || (element.attributes && $(element).attr('data-msglabel'));
+
+         if (t == null)
+         {
+            var lbl = $("label[for='" + element.id + "'][generated!='true']");  // jquery-validate creates a label to host the error message. 
+                                                                              // It assigns a custom attribute, 'generated=true' to that label. 
+                                                                              // We need to avoid it.
+            if (lbl)
+            {
+               t = lbl.html();
+               if (t)
+               {
+                 // strip the HTML tags. Tags are always "<" + 1 or more characters + ">".
+                  t = t.replace(/\<(.|\n)+?\>/ig, "");
+
+                  // if it came from a label, strip lead and trail non-alpha numeric text.
+                  t = t.replace(/[^\dA-Za-z]+$/, ""); // trail non-alpha numeric
+                  t = t.replace(/^[^\dA-Za-z]+/, ""); // lead
+
+                 // update data-label to avoid searching each time
+                  element.setAttribute("data-msglabel", t);
+               }
+            }
+         }
+         return t;   // may be null
+      },
+
+
+// Hosts validation function names mapped to token replacement functions.
+// Each function takes these parameters and returns the updated message string:
+//   message (string) - text to modify.
+//   element (DOM Element)
+//   param - same parameters collection used elsewhere. Data is specific to the individual function.
+//   value - The value that was found to be invalid
+// Those functions not explicitly declared use $.validator.defaultTokenReplacer
+	replaceTokens: {
+
+   // Supported tokens:
+   // {MIN} - The value from param identifying the minimum length
+   // {LENGTH} - The current length
+   // {DIFF} - The difference between the length and the minimum
+		minlength: function(message, element, param, value) {
+         message = $.validator.minMaxReplacer(message, param, null, value.length);
+         return $.validator.defaultTokenReplacer(message, element, param, value);
+		},
+
+   // Supported tokens:
+   // {MAX} - The value from param identifying the maximum length
+   // {LENGTH} - The current length
+   // {DIFF} - The difference between the length and the maximum
+		maxlength: function(message, element, param, value) {
+         message = $.validator.minMaxReplacer(message, null, param, value.length);
+         return $.validator.defaultTokenReplacer(message, element, param, value);
+		},
+
+   // Supported tokens:
+   // {MIN} - The value from param identifying the minimum length
+   // {MAX} - The value from param identifying the maximum length
+   // {LENGTH} - The current length
+   // {DIFF} - The difference between the length and the minimum or maximum
+		rangelength: function(message, element, param, value) {
+         message = $.validator.minMaxReplacer(message, param[0], param[1], value.length);
+         return $.validator.defaultTokenReplacer(message, element, param, value);
+		},
+
+   // Supported tokens:
+   // {MIN} - The value from param identifying the minimum value
+		min: function(message, element, param, value) {
+         message = $.validator.minMaxReplacer(message, param, null, null);
+         return $.validator.defaultTokenReplacer(message, element, param, value);
+		},
+
+   // Supported tokens:
+   // {MAX} - The value from param identifying the maximum value
+		max: function(message, element, param, value) {
+         message = $.validator.minMaxReplacer(message, null, param, null);
+         return $.validator.defaultTokenReplacer(message, element, param, value);
+		},
+
+   // Supported tokens:
+   // {MIN} - The value from param identifying the minimum value
+   // {MAX} - The value from param identifying the maximum value
+		range: function(message, element, param, value) {
+         message = $.validator.minMaxReplacer(message, param[0], param[1], null);
+         return $.validator.defaultTokenReplacer(message, element, param, value);
+		}
 	}
 
 });


### PR DESCRIPTION
Introduces support for better tokens within error messages. Replaces the
formatAndAdd method where error messages tokens are currently handled.
Introduces a new property called replaceTokens which is similar to the
methods property, hosting token replacement methods specific to each
validation method.
Includes support for all existing validation methods. Most use the
defaultTokenReplacer method. Those with min/max concepts have more token
support.
The ReplaceTokens test.html file provides a live example.
