### PR TITLE
Issue 156 Fix for Ignore Not Working Properly

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -359,6 +359,10 @@ $.extend($.validator, {
 
 		// http://docs.jquery.com/Plugins/Validation/Validator/element
 		element: function( element ) {
+			//if the element is set to be ignored, don't continue validation
+			if ( $(element).not(this.settings.ignore).length === 0 ) {
+				return;
+				}
 			element = this.validationTargetFor( this.clean( element ) );
 			this.lastElement = element;
 			this.prepareElement( element );


### PR DESCRIPTION
This patch makes the plugin actually ignore specified fields. Currently (as of jQuery 1.7.2 and Validation 1.9.0) a field specified to be ignored still runs through the validator and comes back as invalid.
