### PR TITLE
Remote rule: Change response type to text

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1033,7 +1033,7 @@ $.extend($.validator, {
 				url: param,
 				mode: "abort",
 				port: "validate" + element.name,
-				dataType: "json",
+				dataType: "text",
 				data: data,
 				success: function(response) {
 					validator.settings.messages[element.name].remote = previous.originalMessage;


### PR DESCRIPTION
The response type is defined as JSON yet is treated as text. Also, jQuery
doesn't call the success callback despite the response is a success as
it doesn't acknowledge a string is a JSON object.
