### PR TITLE
Allow groups option to be an array so that it allows spaces in field names

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -307,7 +307,10 @@ $.extend($.validator, {
 
 			var groups = (this.groups = {});
 			$.each(this.settings.groups, function(key, value) {
-				$.each(value.split(/\s/), function(index, name) {
+				if(typeof value === 'string') {
+					value = value.split(/\s/);
+				}
+				$.each(value, function(index, name) {
 					groups[name] = key;
 				});
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -796,6 +796,22 @@ test("ajaxSubmit", function() {
 	jQuery("#signupForm").triggerHandler("submit");
 });
 
+test("validating groups settings parameter", function() {
+    var form = $("<form>");
+    var validate = form.validate({
+        groups: {
+            arrayGroup: ["input one", "input-two", "input three"],
+            stringGroup: "input-four input-five input-six"
+        },
+    });
+    equal(validate.groups["input one"], "arrayGroup");
+    equal(validate.groups["input-two"], "arrayGroup");
+    equal(validate.groups["input three"], "arrayGroup");
+    equal(validate.groups["input-four"], "stringGroup");
+    equal(validate.groups["input-five"], "stringGroup");
+    equal(validate.groups["input-six"], "stringGroup");
+});
+
 
 module("misc");
 


### PR DESCRIPTION
Field names can contain spaces (as they are a CDATA type). This causes problems with groups, as the string listing the fields is split on spaces.

This commit allows the groups option to be either a space-separated string or an array of strings so that field names with spaces can be added as an array.
