### PR TITLE
Added errorMessageTemplate option for validate() method - allow custom HTML for generated errors.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -217,6 +217,7 @@ $.extend($.validator, {
 		onsubmit: true,
 		ignore: ":hidden",
 		ignoreTitle: false,
+        errorMessageTemplate: "{0}",
 		onfocusin: function(element, event) {
 			this.lastActive = element;
 
@@ -684,14 +685,14 @@ $.extend($.validator, {
 
 				// check if we have a generated label, replace the message then
 				if ( label.attr("generated") ) {
-					label.html(message);
+					label.html(this.formatErrorMessage(message));
 				}
 			} else {
 				// create label
 				label = $("<" + this.settings.errorElement + "/>")
 					.attr({"for":  this.idOrName(element), generated: true})
 					.addClass(this.settings.errorClass)
-					.html(message || "");
+					.html(this.formatErrorMessage(message));
 				if ( this.settings.wrapper ) {
 					// make sure the element is visible, even in IE
 					// actually showing the wrapped element is handled elsewhere
@@ -715,6 +716,13 @@ $.extend($.validator, {
 			}
 			this.toShow = this.toShow.add(label);
 		},
+
+        formatErrorMessage: function( message ) {
+            if (message !== undefined) {
+                return $.validator.format( this.settings.errorMessageTemplate, message );
+            }
+            else return "";
+        },
 
 		errorsFor: function(element) {
 			var name = this.idOrName(element);

--- a/test/test.js
+++ b/test/test.js
@@ -287,6 +287,30 @@ test("submitHandler keeps submitting button", function() {
 	$("#userForm").submit();
 });
 
+ 
+test("formatErrorMessage() - undefined handling" ,function() {
+    expect( 1 );
+    var v = $('#testForm1').validate();
+    v.formatErrorMessage(undefined);
+    ok(true, "No exception raised");
+});
+
+test("formatErrorMessage() - pattern replacement (default)" ,function() {
+    expect( 1 );
+    var v = $('#testForm1').validate();
+    var errorMessage = "some error message";
+    equal(errorMessage, v.formatErrorMessage(errorMessage));
+});
+
+test("formatErrorMessage() - pattern replacement (custom)" ,function() {
+    expect( 1 );
+    var errorTemplate = "aaa {0} bbb"
+    var v = $('#testForm1').validate({ errorMessageTemplate: errorTemplate });
+    var errorMessage = "ccc";
+    equal("aaa ccc bbb", v.formatErrorMessage(errorMessage));
+});
+
+
 test("showErrors()", function() {
 	expect( 4 );
 	var errorLabel = $('#errorFirstname').hide();
@@ -361,6 +385,25 @@ test("showErrors() - custom handler", function() {
 		}
 	});
 	v.form();
+});
+
+test("showErrors(), errorMessageTemplate replacement", function() {
+       $("#userForm").validate({
+               rules: {
+                       username: {
+                               minlength: 3
+                       }
+               },
+               messages: {
+                       username: {
+                               minlength: "too short"
+                       }
+               },
+        errorMessageTemplate: "<a>{0}</a>"
+       });
+       $("#username").val("ab");
+       ok( !$("#username").valid() );
+       equal( "<a>too short</a>", $("label.error[for=username]").html() );
 });
 
 test("option: (un)highlight, default", function() {


### PR DESCRIPTION
Allows to create custom HTML structures as error messages.
Example:

$("#my_form").validate({
    rules: { username: 'required'  },
    messages: { username: { required: "Username is required"  }  },
    errorMessageTemplate: "&lt;a href='#'&gt; {0} &lt;/a&gt;"
} )

The corresponding generated error HTML:

&lt;label for=&quot;username&quot; generated=&quot;true&quot; class=&quot;error&quot;&gt;&lt;a href=&quot;#&quot;&gt; Username is required &lt;/a&gt;&lt;/label&gt;
