### PR TITLE
Fixed a javascript error: validator undefined

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -891,7 +891,7 @@ $.extend($.validator, {
 	staticRules: function(element) {
 		var rules = {};
 		var validator = $.data(element.form, 'validator');
-		if (validator.settings.rules) {
+		if (validator && validator.settings.rules) {
 			rules = $.validator.normalizeRule(validator.settings.rules[element.name]) || {};
 		}
 		return rules;


### PR DESCRIPTION
For some reason the static rules function is being called on a form that the validator was never bound to. This extra check will at least suppress this error until someone can figure out why this function is being called referencing a form that was never associated with the validator.
