### PR TITLE
Ignore min and max on HTML5 date inputs

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -862,6 +862,11 @@ $.extend($.validator, {
 				value = $element.attr(method);
 			}
 
+			// HTML5 uses min and max to restrict dates, do not apply number validation
+			if($element[0].getAttribute("type") === "date" && (method === "min" || method === "max") ) {
+				continue;
+			}
+
 			if (value) {
 				rules[method] = value;
 			} else if ($element[0].getAttribute("type") === method) {

--- a/test/index.html
+++ b/test/index.html
@@ -155,6 +155,10 @@
 			<input name="testForm12text" id="testForm12text" class="{required:true}" />
 		</form>
 
+		<form id="testForm13">
+			<input name="testForm13date" id="testForm13date" type="date" min="1980-02-11" max="1990-01-01" />
+		</form>
+
 		<form id="dataMessages">
 			<input name="dataMessagesName" id="dataMessagesName" class="required" data-msg-required="You must enter a value here" />
 		</form>

--- a/test/rules.js
+++ b/test/rules.js
@@ -22,6 +22,12 @@ test("rules() HTML5 required (no value)", function() {
 	deepEqual( element.rules(), { required: true } );
 });
 
+test("rules() HTML5 date ignore min and max", function() {
+	var element = $('#testForm13date');
+	var v = $('#testForm13').validate();
+	deepEqual( element.rules(), { date: true } );
+});
+
 test("rules() - internal - select", function() {
 	var element = $('#meal');
 	var v = $('#testForm3').validate();


### PR DESCRIPTION
Issue #455

HTML5 uses min and max to restrict the calendar input for date inputs. This patch makes jQuery Validate ignore those attributes on date inputs.
