### PR TITLE
Remote validation not firing properly

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1017,9 +1017,6 @@ $.extend($.validator, {
 
 			param = typeof param === "string" && {url:param} || param;
 
-			if ( this.pending[element.name] ) {
-				return "pending";
-			}
 			if ( previous.old === value ) {
 				return previous.valid;
 			}


### PR DESCRIPTION
I removed the if pending -> return in the remote() function.
This return preventing the ajax call from being fired when the input was changed while an ajax request was already ongoing. Anyway the request was already being aborted if settings.mode = abort.

Another wait to avoid sending too much requests to the server would be to delay the call until the user is done typing. (something like: http://stackoverflow.com/questions/10124114/wait-for-function-till-user-stops-typing).
