### PR TITLE
Fixed synchronised remote calls. 

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -382,7 +382,6 @@ $.extend($.validator, {
 			if(errors) {
 				// add items to error list and map
 				$.extend( this.errorMap, errors );
-				this.errorList = [];
 				for ( var name in errors ) {
 					this.errorList.push({
 						message: errors[name],


### PR DESCRIPTION
Fix as described in Issue #517.
- Removed line 385 this.errorList = [];

When using async=false remote-validation errormessages of the fields
above (in html) won't show up.
