### PR TITLE
Add prioritization of configured error message over remote result.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1044,7 +1044,13 @@ $.extend($.validator, {
 						validator.showErrors();
 					} else {
 						var errors = {};
-						var message = response || validator.defaultMessage( element, "remote" );
+            var defaultMessage = validator.defaultMessage( element, "remote" );
+
+            if (/^!/.match(defaultMessage)) {
+              response = defaultMessage.replace(/^!/, "")  
+            }
+
+						var message = response || defaultMessage;
 						errors[element.name] = previous.message = $.isFunction(message) ? message(value) : message;
 						validator.invalid[element.name] = true;
 						validator.showErrors(errors);


### PR DESCRIPTION
There needs to be a way to say: "no matter what the remote call gives you, please use the error message that I provided, instead of the response from the back end." I do this by saying, if the error message configured starts with an exclamation mark (!), use it (after removing the exclamation mark), otherwise, feel free to use the response.
