### PR TITLE
Removed spaces with multiple MIME types

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -404,7 +404,7 @@ jQuery.validator.addMethod("skip_or_fill_minimum", function(value, element, opti
 // Accept a value from a file input based on a required mimetype
 jQuery.validator.addMethod("accept", function(value, element, param) {
 	// Split mime on commas incase we have multiple types we can accept
-	var typeParam = typeof param === "string" ? param.replace(/,/g, '|') : "image/*",
+	var typeParam = typeof param === "string" ? param.replace(/\s/g, '').replace(/,/g, '|') : "image/*",
 	optionalValue = this.optional(element),
 	i, file;
 


### PR DESCRIPTION
If multiple MIME-types are specified, this will get rid of any extra spaces between them.

`audio/mp3, audio/m4v`

becomes

`audio/mp3,audio/m4v`

for parsing successfully.
