### PR TITLE
Removed dots at end of sentences

### DIFF
--- a/localization/messages_he.js
+++ b/localization/messages_he.js
@@ -19,6 +19,5 @@ jQuery.extend(jQuery.validator.messages, {
 	rangelength: jQuery.validator.format("נא למלא ערך בין {0} ל- {1} תווים"),
 	range: jQuery.validator.format("נא למלא ערך בין {0} ל- {1}"),
 	max: jQuery.validator.format("נא למלא ערך קטן או שווה ל- {0}"),
-	min: jQuery.validator.format("נא למלא ערך גדול או שווה ל- {0}"),
-	greaterThan: jQuery.validator.format('צריך להיות מאוחר יותר מאשר {0}')
+	min: jQuery.validator.format("נא למלא ערך גדול או שווה ל- {0}")
 });


### PR DESCRIPTION
The dots are not necessary and they sometimes display on the wrong side of the sentence
