### PR TITLE
Update additional-methods.js

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -395,7 +395,7 @@ jQuery.validator.addMethod("skip_or_fill_minimum", function(value, element, opti
 	if(!$(element).data('being_validated')) {
 		var fields = $(selector, element.form);
 		fields.data('being_validated', true);
-		fields.valid();
+		fields.validate();
 		fields.data('being_validated', false);
 	}
 	return valid;


### PR DESCRIPTION
Need to change the custom method "skip_or_fill_minimum", otherwise the entire form will submit if just those fields are valid (even if other fields are invalid).

The author notes this change here, but it was not implemented here: http://stackoverflow.com/questions/1888976/jquery-validate-either-skip-these-fields-or-fill-at-least-x-of-them
