### PR TITLE
 Added highlight/unhighlight per rule

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -539,7 +539,13 @@ $.extend($.validator, {
 				var rule = { method: method, parameters: rules[method] };
 				try {
 
-					result = $.validator.methods[method].call( this, val, element, rule.parameters );
+					if($.validator.methods[method]) {
+						result = $.validator.methods[method].call( this, val, element, rule.parameters );
+					} else {
+						if(rules[method].getResult)
+							result = rules[method].getResult.call( this, val, element, rule.parameters );
+						else result = rules[method];
+					}
 
 					// if a method indicates that the field is optional and therefore valid,
 					// don't mark it as valid when there are no other rules


### PR DESCRIPTION
Added functionality to add highlighting and unhighlighting options to individual rules which will override any set highlighting or unhighlighting in the main settings

ex:

```
$('#myform').validate({
    'rules': {
        'name': {
            'required': {
                'highlight': function(element, errorClass, validClass) {
                    // Do something ...
                },
                'unhighlight': function(element, errorClass, validClass) {
                    // Do something ...
                }
            }
        }
    }
});
```
