### PR TITLE
Changed order of highlightning/unhighlightning

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -631,6 +631,11 @@ $.extend($.validator, {
 
 		defaultShowErrors: function() {
 			var i, elements;
+			if (this.settings.unhighlight) {
+				for ( i = 0, elements = this.validElements(); elements[i]; i++ ) {
+					this.settings.unhighlight.call( this, elements[i], this.settings.errorClass, this.settings.validClass );
+				}
+			}
 			for ( i = 0; this.errorList[i]; i++ ) {
 				var error = this.errorList[i];
 				if ( this.settings.highlight ) {
@@ -644,11 +649,6 @@ $.extend($.validator, {
 			if (this.settings.success) {
 				for ( i = 0; this.successList[i]; i++ ) {
 					this.showLabel( this.successList[i] );
-				}
-			}
-			if (this.settings.unhighlight) {
-				for ( i = 0, elements = this.validElements(); elements[i]; i++ ) {
-					this.settings.unhighlight.call( this, elements[i], this.settings.errorClass, this.settings.validClass );
 				}
 			}
 			this.toHide = this.toHide.not( this.toShow );


### PR DESCRIPTION
The reason: I have group of fields, with custom highlight/unhighlight 
function.
I add 'error' class to bootstrap 'div.control-group' on error.
So, if I have one field valid and one invalid in the same 'div.control-group',
all div by default will be valid, that is not expected behaviour.
I dunno, maybe these changes doesn't breaks things, so the only way is set showErrors option.
