### PR TITLE
Validation of IBAN (Internation Bank Account Number)

### DIFF
--- a/additional-methods.js
+++ b/additional-methods.js
@@ -210,6 +210,283 @@ jQuery.validator.addMethod("bankorgiroaccountNL", function(value, element) {
 			($.validator.methods["giroaccountNL"].call(this, value, element));
 }, "Please specify a valid bank or giro account number");
 
+/**
+ * IBAN is the international bank account number. 
+ * It has a country - specific format, that is checked here too 
+ */
+jQuery.validator.addMethod("iban", function(value, element) {
+	// some quick simple tests to prevent needless work
+	if (this.optional(element)) {
+		return true;
+	}
+	if (!(/^([a-zA-Z0-9]{4} ){2,8}[a-zA-Z0-9]{1,4}|[a-zA-Z0-9]{12,34}$/.test(value))) {
+		return false;
+	}
+	
+	// check the country code and find the country specific format
+	var iban = value.replace(/ /g,'').toUpperCase(); // remove spaces and to upper case
+	var countrycode = iban.substring(0,2);
+	var bbanformat = "";
+	var bbanpattern = "";
+	switch (countrycode) {
+		case 'AL':
+			bbanformat = "8n16c";
+			break;
+		case 'AD':
+			bbanformat = "8n12c";
+			break;
+		case 'AT':
+			bbanformat = "16n";
+			break;
+		case 'AZ':
+			bbanformat = "4c20n";
+			break;
+		case 'BE':
+			bbanformat = "12n";
+			break;
+		case 'BH':
+			bbanformat = "4a14c";
+			break;
+		case 'BA':
+			bbanformat = "16n";
+			break;
+		case 'BR':
+			bbanformat = "23n1a1c";
+			break;
+		case 'BG':
+			bbanformat = "4a6n8c";
+			break;
+		case 'CR':
+			bbanformat = "17n";
+			break;
+		case 'HR':
+			bbanformat = "17n";
+			break;
+		case 'CY':
+			bbanformat = "8n16c";
+			break;
+		case 'CZ':
+			bbanformat = "20n";
+			break;
+		case 'DK':
+			bbanformat = "14n";
+			break;
+		case 'DO':
+			bbanformat = "4a20n";
+			break;
+		case 'EE':
+			bbanformat = "16n";
+			break;
+		case 'FO':
+			bbanformat = "14n";
+			break;
+		case 'FI':
+			bbanformat = "14n";
+			break;
+		case 'FR':
+			bbanformat = "10n11c2n";
+			break;
+		case 'GE':
+			bbanformat = "2c16n";
+			break;
+		case 'DE':
+			bbanformat = "18n";
+			break;
+		case 'GI':
+			bbanformat = "4a15c";
+			break;
+		case 'GR':
+			bbanformat = "7n16c";
+			break;
+		case 'GL':
+			bbanformat = "14n";
+			break;
+		case 'GT':
+			bbanformat = "4c20c";
+			break;
+		case 'HU':
+			bbanformat = "24n";
+			break;
+		case 'IS':
+			bbanformat = "22n";
+			break;
+		case 'IE':
+			bbanformat = "4c14n";
+			break;
+		case 'IL':
+			bbanformat = "19n";
+			break;
+		case 'IT':
+			bbanformat = "1a10n12c";
+			break;
+		case 'KZ':
+			bbanformat = "3n13c";
+			break;
+		case 'KW':
+			bbanformat = "4a22c";
+			break;
+		case 'LV':
+			bbanformat = "4a13c";
+			break;
+		case 'LB':
+			bbanformat = "4n20c";
+			break;
+		case 'LI':
+			bbanformat = "5n12c";
+			break;
+		case 'LT':
+			bbanformat = "16n";
+			break;
+		case 'LU':
+			bbanformat = "3n13c";
+			break;
+		case 'MK':
+			bbanformat = "3n10c2n";
+			break;
+		case 'MT':
+			bbanformat = "4a5n18c";
+			break;
+		case 'MR':
+			bbanformat = "23n";
+			break;
+		case 'MU':
+			bbanformat = "4a19n3a";
+			break;
+		case 'MC':
+			bbanformat = "10n11c2n";
+			break;
+		case 'MD':
+			bbanformat = "2c18n";
+			break;
+		case 'ME':
+			bbanformat = "18n";
+			break;
+		case 'NL':
+			bbanformat = "4a10n";
+			break;
+		case 'NO':
+			bbanformat = "11n";
+			break;
+		case 'PK':
+			bbanformat = "4c16n";
+			break;
+		case 'PS':
+			bbanformat = "4c21n";
+			break;
+		case 'PL':
+			bbanformat = "24n";
+			break;
+		case 'PT':
+			bbanformat = "21n";
+			break;
+		case 'RO':
+			bbanformat = "4a16c";
+			break;
+		case 'SM':
+			bbanformat = "1a10n12c";
+			break;
+		case 'SA':
+			bbanformat = "2n18c";
+			break;
+		case 'RS':
+			bbanformat = "18n";
+			break;
+		case 'SK':
+			bbanformat = "20n";
+			break;
+		case 'SI':
+			bbanformat = "15n";
+			break;
+		case 'ES':
+			bbanformat = "20n";
+			break;
+		case 'SE':
+			bbanformat = "20n";
+			break;
+		case 'CH':
+			bbanformat = "5n12c";
+			break;
+		case 'TN':
+			bbanformat = "20n";
+			break;
+		case 'TR':
+			bbanformat = "5n17c";
+			break;
+		case 'AE':
+			bbanformat = "3n16n";
+			break;
+		case 'GB':
+			bbanformat = "4a14n";
+			break;
+		case 'VG':
+			bbanformat = "4c16n";
+			break;
+	}
+	if (bbanformat === "") {
+		return false; // unknown country: MAYBE WE SHOULD ALLOW THIS???
+	}
+	
+	// check the country specific format
+	while (bbanformat.length>1) {
+		var count = 0;
+		var type = "?";
+		var l = 0;
+		if (/^\d[acn]/.test(bbanformat)) {
+			l = 1;
+		} else { 
+			l = 2;
+		}
+		
+		count = bbanformat.substring(0, l);
+		type = bbanformat.substring(l, l + 1);
+		bbanformat = bbanformat.substring(l + 1, bbanformat.length);
+		if (count === 0) {
+			break; // this indicates illegal bbanformat string: MAYBE HANDLE???
+		}
+		var typeexpression = '';
+		switch (type) {
+		case 'a': // alphabet letter
+			typeexpression = '[A-Z]';
+			break;
+		case 'c': // character (digit or letter)
+			typeexpression = '[\\dA-Z]';
+			break;
+		case 'n': // number (digit actually)
+			typeexpression = '\\d';
+			break;
+		}
+		bbanpattern = bbanpattern + typeexpression + "{" + count + "}";
+	}
+	var ibanregexp = new RegExp("^[A-Z]{2}\\d{2}" + bbanpattern + "$", "");
+	if (!(ibanregexp.test(iban))) {
+		return false; // invalid country specific format
+	}
+	
+	// now check the checksum, first convert to digits
+	var ibancheck = iban.substring(4,iban.length) + iban.substring(0,4);
+	var ibancheckdigits = "";
+	var leadingZeroes = true;
+	for (var i =0; i<ibancheck.length; i++) {
+		var char = ibancheck.charAt(i);
+		if (char !== "0") {
+			leadingZeroes = false;
+		}
+		if (!leadingZeroes) {
+			ibancheckdigits += "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(char);
+		}
+	}
+
+	// calculate the result of: ibancheckdigits % 97
+    var cRest = '';
+    var cOperator = '';
+	for (var p=0; p<ibancheckdigits.length; p++) {
+		var cChar = ibancheckdigits.charAt(p);
+		cOperator = '' + cRest + '' + cChar;
+		cRest = cOperator % 97;
+    }
+	return cRest === 1;
+}, "Please specify a valid IBAN");
+
 jQuery.validator.addMethod("time", function(value, element) {
 	return this.optional(element) || /^([01]\d|2[0-3])(:[0-5]\d){1,2}$/.test(value);
 }, "Please enter a valid time, between 00:00 and 23:59");

--- a/localization/messages_nl.js
+++ b/localization/messages_nl.js
@@ -29,6 +29,7 @@
 		postalcodeNL: "Vul hier een geldige postcode in.",
 		bankaccountNL: "Vul hier een geldig bankrekeningnummer in.",
 		giroaccountNL: "Vul hier een geldig gironummer in.",
-		bankorgiroaccountNL: "Vul hier een geldig bank- of gironummer in."
+		bankorgiroaccountNL: "Vul hier een geldig bank- of gironummer in.",
+		iban: "Vul hier een geldig IBAN in."
 	});
 }(jQuery));

--- a/test/methods.js
+++ b/test/methods.js
@@ -666,6 +666,79 @@ test("bankorgiroaccountNL", function() {
 	ok(!method( "123456788"), "Invalid NL bank or giro account");
 });
 
+test("iban", function() {
+	var method = methodTest("iban");
+	ok( method( "NL20INGB0001234567"), "Valid IBAN");
+	ok( method( "DE68 2105 0170 0012 3456 78"), "Valid IBAN");
+	ok( method( "NL20 INGB0001234567"), "Valid IBAN: invalid spacing");
+	ok( method( "NL20 INGB 00 0123 4567"), "Valid IBAN: invalid spacing");
+	
+	ok(!method( "NL20INGB000123456"), "Invalid IBAN: too short");
+	ok(!method( "NL20INGB00012345678"), "Invalid IBAN: too long");
+	ok(!method( "NL20INGB0001234566"), "Invalid IBAN: checksum incorrect");
+	ok(!method( "DE68 2105 0170 0012 3456 7"), "Invalid IBAN: too short");
+	ok(!method( "DE68 2105 0170 0012 3456 789"), "Invalid IBAN: too long");
+	ok(!method( "DE68 2105 0170 0012 3456 79"), "Invalid IBAN: checksum incorrect");
+
+	// sample IBANs for different countries
+	ok( method( "AL47 2121 1009 0000 0002 3569 8741"), "Valid IBAN - AL");
+	ok( method( "AD12 0001 2030 2003 5910 0100"), "Valid IBAN - AD");
+	ok( method( "AT61 1904 3002 3457 3201"), "Valid IBAN - AT");
+	ok( method( "AZ21 NABZ 0000 0000 1370 1000 1944"), "Valid IBAN - AZ");
+	ok( method( "BH67 BMAG 0000 1299 1234 56"), "Valid IBAN - BH");
+	ok( method( "BE62 5100 0754 7061"), "Valid IBAN - BE");
+	ok( method( "BA39 1290 0794 0102 8494"), "Valid IBAN - BA");
+	ok( method( "BG80 BNBG 9661 1020 3456 78"), "Valid IBAN - BG");
+	ok( method( "HR12 1001 0051 8630 0016 0"), "Valid IBAN - HR");
+	ok( method( "CH93 0076 2011 6238 5295 7"), "Valid IBAN - CH");
+	ok( method( "CY17 0020 0128 0000 0012 0052 7600"), "Valid IBAN - CY");
+	ok( method( "CZ65 0800 0000 1920 0014 5399"), "Valid IBAN - CZ");
+	ok( method( "DK50 0040 0440 1162 43"), "Valid IBAN - DK");
+	ok( method( "EE38 2200 2210 2014 5685"), "Valid IBAN - EE");
+	ok( method( "FO97 5432 0388 8999 44"), "Valid IBAN - FO");
+	ok( method( "FI21 1234 5600 0007 85"), "Valid IBAN - FI");
+	ok( method( "FR14 2004 1010 0505 0001 3M02 606"), "Valid IBAN - FR");
+	ok( method( "GE29 NB00 0000 0101 9049 17"), "Valid IBAN - GE");
+	ok( method( "DE89 3704 0044 0532 0130 00"), "Valid IBAN - DE");
+	ok( method( "GI75 NWBK 0000 0000 7099 453"), "Valid IBAN - GI");
+	ok( method( "GR16 0110 1250 0000 0001 2300 695"), "Valid IBAN - GR");
+	ok( method( "GL56 0444 9876 5432 10"), "Valid IBAN - GL");
+	ok( method( "HU42 1177 3016 1111 1018 0000 0000"), "Valid IBAN - HU");
+	ok( method( "IS14 0159 2600 7654 5510 7303 39"), "Valid IBAN - IS");
+	ok( method( "IE29 AIBK 9311 5212 3456 78"), "Valid IBAN - IE");
+	ok( method( "IL62 0108 0000 0009 9999 999"), "Valid IBAN - IL");
+	ok( method( "IT40 S054 2811 1010 0000 0123 456"), "Valid IBAN - IT");
+	ok( method( "LV80 BANK 0000 4351 9500 1"), "Valid IBAN - LV");
+	ok( method( "LB62 0999 0000 0001 0019 0122 9114"), "Valid IBAN - LB");
+	ok( method( "LI21 0881 0000 2324 013A A"), "Valid IBAN - LI");
+	ok( method( "LT12 1000 0111 0100 1000"), "Valid IBAN - LT");
+	ok( method( "LU28 0019 4006 4475 0000"), "Valid IBAN - LU");
+	ok( method( "MK07 2501 2000 0058 984"), "Valid IBAN - MK");
+	ok( method( "MT84 MALT 0110 0001 2345 MTLC AST0 01S"), "Valid IBAN - MT");
+	ok( method( "MU17 BOMM 0101 1010 3030 0200 000M UR"), "Valid IBAN - MU");
+	ok( method( "MD24 AG00 0225 1000 1310 4168"), "Valid IBAN - MD");
+	ok( method( "MC93 2005 2222 1001 1223 3M44 555"), "Valid IBAN - MC");
+	ok( method( "ME25 5050 0001 2345 6789 51"), "Valid IBAN - ME");
+	ok( method( "NL39 RABO 0300 0652 64"), "Valid IBAN - NL");
+	ok( method( "NO93 8601 1117 947"), "Valid IBAN - NO");
+	ok( method( "PK36 SCBL 0000 0011 2345 6702"), "Valid IBAN - PK");
+	ok( method( "PL60 1020 1026 0000 0422 7020 1111"), "Valid IBAN - PL");
+	ok( method( "PT50 0002 0123 1234 5678 9015 4"), "Valid IBAN - PT");
+	ok( method( "RO49 AAAA 1B31 0075 9384 0000"), "Valid IBAN - RO");
+	ok( method( "SM86 U032 2509 8000 0000 0270 100"), "Valid IBAN - SM");
+	ok( method( "SA03 8000 0000 6080 1016 7519"), "Valid IBAN - SA");
+	ok( method( "RS35 2600 0560 1001 6113 79"), "Valid IBAN - RS");
+	ok( method( "SK31 1200 0000 1987 4263 7541"), "Valid IBAN - SK");
+	ok( method( "SI56 1910 0000 0123 438"), "Valid IBAN - SI");
+	ok( method( "ES80 2310 0001 1800 0001 2345"), "Valid IBAN - ES");
+	ok( method( "SE35 5000 0000 0549 1000 0003"), "Valid IBAN - SE");
+	ok( method( "CH93 0076 2011 6238 5295 7"), "Valid IBAN - CH");
+	ok( method( "TN59 1000 6035 1835 9847 8831"), "Valid IBAN - TN");
+	ok( method( "TR33 0006 1005 1978 6457 8413 26"), "Valid IBAN - TR");
+	ok( method( "AE07 0331 2345 6789 0123 456"), "Valid IBAN - AE");
+	ok( method( "GB29 NWBK 6016 1331 9268 19"), "Valid IBAN - GB");
+});
+
 test("time", function() {
 	var method = methodTest("time");
 	ok( method("00:00"), "Valid time, lower bound" );


### PR DESCRIPTION
Please have a look at this. Although it works for me, there are a few things to think about:
- IBAN will be introduced all over EU (and more) over the next years, maybe it should be in the main validate.js, and not in additional methods? At least it is a reason to think it over carefully: naming, location, maybe split per country.
- the code is quite long, maybe it can be shorter / more efficient? Especially the way the regexp for the country specific check can be build in other ways, or even be defined directly for every country (longer, but more clear: now a 'definition' string is parsed to build the regexp)
- There is a country-specific format check done now, just before the 'real' checksum check. This helps to block invalid IBANs (correct checksum, but incorrect country specific format) but will also block valid IBANS if a new country starts to use IBAN or if a country specific format will change in the future (I doubt the latter will ever happen, the first will though). So I think we should eigther provide 2 checks (iban and ibanwithoutcountrycheck) OR allow unknown countries, and just for those not check the format....
- At least in theory the check could be more specific, as within the 'local' account number there can be another checksum / limitations that are not checked now. I think this is not really needed though, as the checksum in the IBAN itself is quite strong and countries may stop using their local restrictions anyway to just rely in IBAN in the future.
