### PR TITLE
Changed order of validators

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1052,39 +1052,6 @@ $.extend($.validator, {
 			return "pending";
 		},
 
-		// http://docs.jquery.com/Plugins/Validation/Methods/minlength
-		minlength: function( value, element, param ) {
-			var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
-			return this.optional(element) || length >= param;
-		},
-
-		// http://docs.jquery.com/Plugins/Validation/Methods/maxlength
-		maxlength: function( value, element, param ) {
-			var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
-			return this.optional(element) || length <= param;
-		},
-
-		// http://docs.jquery.com/Plugins/Validation/Methods/rangelength
-		rangelength: function( value, element, param ) {
-			var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
-			return this.optional(element) || ( length >= param[0] && length <= param[1] );
-		},
-
-		// http://docs.jquery.com/Plugins/Validation/Methods/min
-		min: function( value, element, param ) {
-			return this.optional(element) || value >= param;
-		},
-
-		// http://docs.jquery.com/Plugins/Validation/Methods/max
-		max: function( value, element, param ) {
-			return this.optional(element) || value <= param;
-		},
-
-		// http://docs.jquery.com/Plugins/Validation/Methods/range
-		range: function( value, element, param ) {
-			return this.optional(element) || ( value >= param[0] && value <= param[1] );
-		},
-
 		// http://docs.jquery.com/Plugins/Validation/Methods/email
 		email: function( value, element ) {
 			// contributed by Scott Gonzalez: http://projects.scottsplayground.com/email_address_validation/
@@ -1148,7 +1115,40 @@ $.extend($.validator, {
 			return (nCheck % 10) === 0;
 		},
 
-		// http://docs.jquery.com/Plugins/Validation/Methods/equalTo
+        // http://docs.jquery.com/Plugins/Validation/Methods/minlength
+        minlength: function( value, element, param ) {
+            var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
+            return this.optional(element) || length >= param;
+        },
+
+        // http://docs.jquery.com/Plugins/Validation/Methods/maxlength
+        maxlength: function( value, element, param ) {
+            var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
+            return this.optional(element) || length <= param;
+        },
+
+        // http://docs.jquery.com/Plugins/Validation/Methods/rangelength
+        rangelength: function( value, element, param ) {
+            var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
+            return this.optional(element) || ( length >= param[0] && length <= param[1] );
+        },
+
+        // http://docs.jquery.com/Plugins/Validation/Methods/min
+        min: function( value, element, param ) {
+            return this.optional(element) || value >= param;
+        },
+
+        // http://docs.jquery.com/Plugins/Validation/Methods/max
+        max: function( value, element, param ) {
+            return this.optional(element) || value <= param;
+        },
+
+        // http://docs.jquery.com/Plugins/Validation/Methods/range
+        range: function( value, element, param ) {
+            return this.optional(element) || ( value >= param[0] && value <= param[1] );
+        },
+
+        // http://docs.jquery.com/Plugins/Validation/Methods/equalTo
 		equalTo: function( value, element, param ) {
 			// bind to the blur event of the target in order to revalidate whenever the target field is updated
 			// TODO find a way to bind the event just once, avoiding the unbind-rebind overhead


### PR DESCRIPTION
... to allow more general validators (number, date) to be executed before more specific ones (min, max, range).

The original issue was that I've attached a number of validators to a field like so:

``` javascript
<input type="text" id="some-value" name="some-value" data-rule-required="true" data-rule-number="true" data-rule-min="1" data-rule-max="5">
```

Since the validators are being checked against sequentially, the min and max validators kick in before the number validator. An example where this becomes obvious is when I enter "a" into the input field and it displays an error that the minimum input is 1 (rather than telling me that it's not a number).
