### PR TITLE
rebased Fix #639/#648 min/max validation

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -863,6 +863,7 @@ $.extend($.validator, {
 					value = Number(value);
 					break;
 				case 'text':
+				case null:
 					value = Number(value);
 					break;
 				}
@@ -876,6 +877,7 @@ $.extend($.validator, {
 					value = Number(value);
 					break;
 				case 'text':
+				case null:
 					value = Number(value);
 					break;
 				}

--- a/test/index.html
+++ b/test/index.html
@@ -311,11 +311,15 @@
 			     you can also use type="number", in which case the browser may also
 			     do validation, and mobile browsers may offer a numeric keypad to edit 
 			     the value.
+			     Type absent is treated like type="text".
 			  -->
 			<input type="text" id="rangeTextInvalidGreater" name="rangeTextInvalidGreater" min="50" max="200" value="1000"/>
 			<input type="text" id="rangeTextInvalidLess" name="rangeTextInvalidLess" min="200" max="1000" value="50"/>
+			<input id="rangeAbsentInvalidGreater" name="rangeAbsentInvalidGreater" min="50" max="200" value="1000"/>
+			<input id="rangeAbsentInvalidLess" name="rangeAbsentInvalidLess" min="200" max="1000" value="50"/>
 
 			<input type="text" id="rangeTextValid" name="rangeTextValid" min="50" max="1000" value="200"/>
+			<input id="rangeAbsentValid" name="rangeTextValid" min="50" max="1000" value="200"/>
 
 			<!-- ranges are like numbers in html5, except that browser is not required 
 			     to demand an exact value.  User interface could be a slider.

--- a/test/rules.js
+++ b/test/rules.js
@@ -205,7 +205,7 @@ test("rules(), add and remove", function() {
 	deepEqual( $("#v2-i5").rules(), { required: true, minlength: 2, maxlength: 5, customMethod1: "123" });
 
 	$("#v2-i5").addClass("email").attr({min: 5});
-	deepEqual( $("#v2-i5").rules(), { required: true, email: true, minlength: 2, maxlength: 5, min: "5", customMethod1: "123" });
+	deepEqual( $("#v2-i5").rules(), { required: true, email: true, minlength: 2, maxlength: 5, min: 5, customMethod1: "123" });
 
 	$("#v2-i5").removeClass("required email").removeAttrs("minlength maxlength customMethod1 min");
 	deepEqual( $("#v2-i5").rules(), {});

--- a/test/test.js
+++ b/test/test.js
@@ -1452,6 +1452,44 @@ test("Min and Max strings set by attributes valid", function() {
 
 
 
+test("Min and Max type absent set by attributes greater", function() {
+	var form = $('#ranges');
+	var name = $('#rangeAbsentInvalidGreater');
+	var v = form.validate();
+
+	form.get(0).reset();
+	name.valid();
+
+	var label = $('#ranges label');
+	equal( label.text(), "Please enter a value less than or equal to 200.", "Correct error label" );
+});
+
+test("Min and Max type absent set by attributes less", function() {
+	var form = $('#ranges');
+	var name = $('#rangeAbsentInvalidLess');
+	var v = form.validate();
+
+	form.get(0).reset();
+	name.valid();
+
+	var label = $('#ranges label');
+	equal( label.text(), "Please enter a value greater than or equal to 200.", "Correct error label" );
+});
+
+test("Min and Max type absent set by attributes valid", function() {
+	var form = $('#ranges');
+	var name = $('#rangeAbsentValid');
+	var v = form.validate();
+
+	form.get(0).reset();
+	name.valid();
+
+	var label = $('#ranges label');
+	equal( label.text(), "", "Correct error label" );
+});
+
+
+
 test("Min and Max range set by attributes valid", function() {
 	//
 	// cannot test for overflow: 


### PR DESCRIPTION
As promissed, here's the min/max commit, rebased to upstream head, 
with the two commits squashed into one.

In 1.10.0, min/max validation was supported for input type="text",
where min/max were interpreted as numbers.  This means min/max
for date would not work: min="2012-02-13" was interpreted as min="Not a Number".

In 1.11.0, min/max were no longer converted to numbers.  This means
min/max for dates worked, but min/max for numbers failed:
"50" < "150" < "1000" does not hold.

For an example, see http://jsbin.com/awokex/3

This commit makes the behaviour of min/max dependent on input type:
- input type=text has numeric min/max, as in 1.10.0
- input type=date has working min/max for type date;
  on mobile browsers you also get a date picker,
  plus the browser may reject invalid dates before
  javascript gets a chance to complain.
- input type=number or range get numeric min/max,
  plus numeric keypad or slider on mobile browsers,
  plus browser may reject invalid input before javascript
  gets a chance to complain

Allowing use of min/max with type=number/range/date is important
for mobile browsers, where the numeric keypad or date picker
make the input much easier to use than a generic text input field.
In this situation jquery-validate remains necessary to support
older browsers that do not do input validation based on type
and min/max.

For situations where numeric input should be validated by jquery
without giving the browser a chance to validate the input format,
input type=text in combination with min/max can be used, as in 1.10.0.

Note that some older browsers do not correctly support Date conversion,
which can cause the validation suite to fail with message "Please enter a valid date."

In particular, this bug hit phantomjs 1.7.0 as used in validating 1.11.0;
the issue is solved in phantomjs 1.8.0 used now.

http://code.google.com/p/phantomjs/issues/detail?id=187#c6
https://github.com/ariya/phantomjs/commit/35c1971595

Tested with chromium, firefox, grunt.
