### PR TITLE
Altered equalTo selector to find compare element in same form

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1152,7 +1152,7 @@ $.extend($.validator, {
 		equalTo: function( value, element, param ) {
 			// bind to the blur event of the target in order to revalidate whenever the target field is updated
 			// TODO find a way to bind the event just once, avoiding the unbind-rebind overhead
-			var target = $(param);
+			var target = $(element).closest('form').find(param);
 			if ( this.settings.onfocusout ) {
 				target.unbind(".validate-equalTo").bind("blur.validate-equalTo", function() {
 					$(element).valid();


### PR DESCRIPTION
equalTo validator will fail when I have 2 forms containing the target element with the same name.

i.e.

```
<form id="test1" name="test1">
    <input type="text" name="somefield" />
    <input type="text" name="somefield_again" />
</form>
<form id="test2" name="test2">
    <input type="text" name="somefield" />
    <input type="text" name="somefield_again" />
</form>
```

And my rules:

```
$('#test2').validate({
    rules : {
         somefield_again : {
             equalTo : "[name='somefield']"
         }
    }
});
```

This would fail in the second form, because `somefield_again` from form `test2` will be compared to `somefield` of `test1`.
