### PR TITLE
Fix for [Range()] Annotation in ASP .NET MVC

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -940,7 +940,7 @@ $.extend($.validator, {
 				rules[this] = Number(rules[this]);
 			}
 		});
-		$.each(['rangelength'], function() {
+		$.each(['rangelength', 'range'], function() {
 			var parts;
 			if ( rules[this] ) {
 				if ( $.isArray(rules[this]) ) {


### PR DESCRIPTION
Updated normalizeRules so that the [Range()] annotation in ASP.NET MVC
will work correctly.

It seems like a relatively small fix to allow ASP .NET MVC applications to continue to work correctly. I believe that this modification was taken out recently for some reason.
