### PR TITLE
Fix issue#700 where calling blur on ignored elements will end up in wrong value returned by valid() method

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -326,9 +326,10 @@ $.extend($.validator, {
 
 			function delegate(event) {
 				var validator = $.data(this[0].form, "validator"),
-					eventType = "on" + event.type.replace(/^validate/, "");
-				if ( validator.settings[eventType] ) {
-					validator.settings[eventType].call(validator, this[0], event);
+					eventType = "on" + event.type.replace(/^validate/, ""),
+					settings = validator.settings;
+				if ( settings[eventType] && !this.is( settings.ignore ) ) {
+					settings[eventType].call(validator, this[0], event);
 				}
 			}
 			$(this.currentForm)

--- a/test/index.html
+++ b/test/index.html
@@ -318,6 +318,15 @@
 				<input id="bypassSubmitWithNoValidate1" type="submit" formnovalidate value="bypass1"/>
 				<input id="bypassSubmitWithNoValidate2" type="submit" formnovalidate="formnovalidate" value="bypass2"/>
 		</form>
+		
+		<form id="ignoredElements">
+			<select id="ss1" class="ignore">
+				<option value="1">option 1</option>
+				<option value="2">option 2</option>
+			</select>
+			<br />
+			<input name="test" class="required" value=""/>
+		</form>
 	</div>
 
 </body>

--- a/test/test.js
+++ b/test/test.js
@@ -1450,4 +1450,18 @@ test("Min and Max strings set by attributes valid", function() {
 	equal( label.text(), "", "Correct error label" );
 });
 
+test("calling blur on ignored element", function() {
+	var form = $( "#ignoredElements" );
+
+	form.validate( {
+		ignore: '.ignore',
+		submitHandler: $.noop,
+		invalidHandler: function() {
+			$( "#ss1" ).blur();
+		}
+	} );
+	
+	form.trigger( "submit" );
+	equal( form.valid(), false, "valid() should return false" );		
+});
 


### PR DESCRIPTION
As discussed in issue 700, <code>valid</code> is returning incorrect value when <code>blur</code> is called on ignored element in the <code>invalidHandler</code>. Although the issue can be worked around by setting false as value of <code>onfocusout</code> option, it is better off fix the <code>delegate</code> method which does the delegation to the appropriate event handler.
