### PR TITLE
Fixed error thrown when element missing name

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -725,7 +725,7 @@ $.extend($.validator, {
 
 		validationTargetFor: function( element ) {
 			// if radio/checkbox, validate first element in group instead
-			if ( this.checkable(element) && element.name != "" ) {
+			if ( this.checkable(element) && element.name !== "" ) {
 				element = this.findByName( element.name ).not(this.settings.ignore)[0];
 			}
 			return element;

--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -725,7 +725,7 @@ $.extend($.validator, {
 
 		validationTargetFor: function( element ) {
 			// if radio/checkbox, validate first element in group instead
-			if ( this.checkable(element) ) {
+			if ( this.checkable(element) && element.name != "" ) {
 				element = this.findByName( element.name ).not(this.settings.ignore)[0];
 			}
 			return element;


### PR DESCRIPTION
I have the following code

``` html
<form id="myform">
    <input type="text" name="name" placeholder="Full Name" required />
    <label class="checkbox">
        <input type="checkbox" required />
        I agree not to send any unsolicited email, or send email to addresses purchased, rented or otherwise obtained from a third party. I understand that port 25 is blocked by default and I have to request that it be opened. I also understand that if I violate the rules set by Server Blaze that port 25 will be closed.
    </label>
    <button type="submit">Done</button>
</form>
```

and in JavaScript I have this

``` javascript
$("#myform").validate()
```

The code always errors out and continues with submit regardless of if a name is entered into the name field or not.  I have tracked the error down to this line:

https://github.com/jzaefferer/jquery-validation/blob/master/jquery.validate.js#L729

With this PR, I fixed the error in the code by skipping the name check if the name doesn't exit.
