### PR TITLE
Possible fix for Issue 156 Ignore Not Working Properly, plus removes errors for ignored elements

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -371,7 +371,8 @@ $.extend($.validator, {
 		element: function( element ) {
 			var cleanElement = this.clean( element );
 			var checkElement = this.validationTargetFor( cleanElement );
-
+			var result = true;
+			
 			this.lastElement = checkElement;
 			
 			if (checkElement === undefined) {
@@ -381,7 +382,7 @@ $.extend($.validator, {
 				this.prepareElement( checkElement );
 				this.currentElements = $(checkElement);
 
-				var result = this.check( checkElement ) !== false;
+				result = this.check( checkElement ) !== false;
 				if (result) {
 					delete this.invalid[checkElement.name];
 				} else {


### PR DESCRIPTION
This patch is similar to the one already submitted for Issue 156, except that it uses the result of validationTargetFor to determine if the element should be checked. 

In addition, if it finds that the element should be ignored it will remove any error messages for that element. This handles the case where a user generates errors, then through other actions the element is hidden and revalidated.
