### PR TITLE
Exposes the hideErrors method

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -436,7 +436,11 @@ $.extend($.validator, {
 		},
 
 		hideErrors: function() {
-			this.addWrapper( this.toHide ).hide();
+			if ( this.settings.hideErrors ) {
+				this.settings.hideErrors.call( this );
+			} else {
+				this.defaultHideErrors();
+			}
 		},
 
 		valid: function() {
@@ -673,6 +677,10 @@ $.extend($.validator, {
 			return $(this.errorList).map(function() {
 				return this.element;
 			});
+		},
+		
+		defaultHideErrors: function() {
+			this.addWrapper( this.toHide ).hide();
 		},
 
 		showLabel: function( element, message ) {


### PR DESCRIPTION
Custom showErrors functions often required custom hideErrors functions. While the success method can be used to provide this, it creates a label on the page that may not be needed. This fills a hole that can be created by users who override jQuery Validate's showErrors functionality.
