### PR TITLE
Add novalidate attribute causes an error in IE7 and lower.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -30,7 +30,7 @@ $.extend($.fn, {
 		}
 
 		// Add novalidate tag if HTML5.
-		this.attr( "novalidate", "novalidate" );
+		this.prop( "novalidate", "novalidate" );
 
 		validator = new $.validator( options, this[0] );
 		$.data( this[0], "validator", validator );


### PR DESCRIPTION
Line 33 causes an error in IE7 and lower. Therefore I substituted $.attr by $.prop method.
