### PR TITLE
Allow validation across all inputs with same name

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -482,12 +482,25 @@ $.extend($.validator, {
 					console.error( "%o has no name assigned", this);
 				}
 
-				// select only the first element for each name, and only those with rules specified
-				if ( this.name in rulesCache || !validator.objectLength($(this).rules()) ) {
+				// filter out checkable elements whose name already in cache
+				if ( validator.checkable(this) && this.name in rulesCache ) {
 					return false;
 				}
 
-				rulesCache[this.name] = true;
+				// select this element (non-checkable) if this has the same name as one in cache
+				if ( this.name in rulesCache ) {
+					if ( !validator.objectLength($(this).rules()) ) {
+						$(this).rules('add', rulesCache[this.name]);
+					}
+					return true;
+				}
+
+				// select only the element with rules specified
+				if ( !validator.objectLength($(this).rules()) ) {
+					return false;
+				}
+
+				rulesCache[this.name] = $(this).rules();
 				return true;
 			});
 		},

--- a/test/rules.js
+++ b/test/rules.js
@@ -39,7 +39,8 @@ test("rules() - external", function() {
 });
 
 test("rules() - external - complete form", function() {
-	expect(1);
+	// twice because #form has two inputs with the name 'action'
+	expect(2);
 
 	var methods = $.extend({}, $.validator.methods);
 	var messages = $.extend({}, $.validator.messages);


### PR DESCRIPTION
The following piece of code in jquery.validate.js, `elements()` function, explicitly ignores all elements with the same name (except for the first)

``` javascript
...
// select only the first element for each name, and only those with rules specified
if ( this.name in rulesCache || !validator.objectLength($(this).rules()) ) {
  return false;
}
...
```

IMO, we should rather apply the same validation rules for the elements with the same name. For which the modified piece of code would be:

``` javascript
elements: function() {
    var validator = this,
        rulesCache = {};

    // select all valid inputs inside the form (no submit or reset buttons)
    return $(this.currentForm)
    .find("input, select, textarea")
    .not(":submit, :reset, :image, [disabled]")
    .not( this.settings.ignore )
    .filter(function() {
        if ( !this.name && validator.settings.debug && window.console ) {
            console.error( "%o has no name assigned", this);
        }

        // select this element if this has the same name as one in cache (may be was dynamically added)
        if ( this.name in rulesCache ) {
            if ( !validator.objectLength($(this).rules()) ) {
                $(this).rules('add', rulesCache[this.name]);
            }
            return true;
        }

        // select only the element with rules specified
        if ( !validator.objectLength($(this).rules()) ) {
            return false;
        }

        // Add rules to the cache
        rulesCache[this.name] = $(this).rules();
        return true;
    });
},
```

What this also makes possible is, if inputs are dynamically added (in case where multi-inputs exist), the same validation would apply to those too.
