### PR TITLE
fix bug in IE7

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -29,7 +29,11 @@ $.extend($.fn, {
 		}
 
 		// Add novalidate tag if HTML5.
-		this.attr( "novalidate", "novalidate" );
+		try {
+			this.attr( "novalidate", "novalidate" );
+		} catch(e){
+			e && console.warn('HTML5 attribute "novalidate" is not supported in this browser!');
+		}
 
 		validator = new $.validator( options, this[0] );
 		$.data( this[0], "validator", validator );


### PR DESCRIPTION
Function validate() will throw an exception and break because HTML5 attribute "novalidate" is not supported by form element in IE7, so I add a try-catch block to give a warning instead of error on console.
