### PR TITLE
Switch zipping package for Grunt release task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,8 +30,14 @@ grunt.initConfig({
 			}
 		}
 	},
-	zip: {
+	compress: {
 		dist: {
+			options: {
+				mode: 'zip',
+				level: 1,
+				archive: 'dist/<%= pkg.name %>-<%= pkg.version %>.zip',
+				pretty: true
+			},
 			src: [
 				'dist/additional-methods.js',
 				'dist/additional-methods.min.js',
@@ -45,13 +51,7 @@ grunt.initConfig({
 				'lib/**/*.*',
 				'localization/**/*.*',
 				'test/**/*.*'
-			],
-			dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.zip'
-		},
-		options: {
-			zlib: {
-				level: 1
-			}
+			]
 		}
 	},
 	qunit: {
@@ -120,9 +120,9 @@ grunt.loadNpmTasks('grunt-contrib-jshint');
 grunt.loadNpmTasks('grunt-contrib-qunit');
 grunt.loadNpmTasks('grunt-contrib-uglify');
 grunt.loadNpmTasks('grunt-contrib-concat');
-grunt.loadNpmTasks('grunt-zipstream');
+grunt.loadNpmTasks('grunt-contrib-compress');
 
 grunt.registerTask('default', ['jshint', 'qunit']);
-grunt.registerTask('release', ['default', 'concat', 'uglify', 'zip']);
+grunt.registerTask('release', ['default', 'concat', 'uglify', 'compress']);
 
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-uglify": "~0.1.1",
     "grunt-contrib-concat": "~0.1.3",
-    "grunt-zipstream": "~0.2.2"
+    "grunt-contrib-compress": "~0.5.2"
   },
   "keywords": [
     "forms",


### PR DESCRIPTION
[grunt-zipstream](https://github.com/Two-Screen/grunt-zipstream) isn't supported on Node 0.10 and [grunt-contrib-compress](https://github.com/gruntjs/grunt-contrib-compress) is the recommended replacement
