### PR TITLE
Restricting credit card validator to include length check

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -1057,6 +1057,12 @@ $.extend($.validator, {
 
 			value = value.replace(/\D/g, "");
 
+			// Basing min and max length on
+			// http://developer.ean.com/general_info/Valid_Credit_Card_Types
+			if ( value.length < 13 || value.length > 19 ) {
+				return false;
+			}
+
 			for (var n = value.length - 1; n >= 0; n--) {
 				var cDigit = value.charAt(n);
 				nDigit = parseInt(cDigit, 10);

--- a/test/methods.js
+++ b/test/methods.js
@@ -340,8 +340,9 @@ test("equalTo", function() {
 
 test("creditcard", function() {
 	var method = methodTest("creditcard");
-	ok( method( "446-667-651" ), "Valid creditcard number" );
-	ok( method( "446 667 651" ), "Valid creditcard number" );
+	ok( method( "4111-1111-1111-1111" ), "Valid creditcard number" );
+	ok( method( "4111 1111 1111 1111" ), "Valid creditcard number" );
+	ok(!method( "41111" ), "Invalid creditcard number" );
 	ok(!method( "asdf" ), "Invalid creditcard number" );
 });
 


### PR DESCRIPTION
Without this, '41111' is a valid credit card number according to the
plugin
