### PR TITLE
Switch dataRules parsing to fall in line with the W3C HTML5 specification

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -886,7 +886,7 @@ $.extend($.validator, {
 		var method, value,
 			rules = {}, $element = $(element);
 		for (method in $.validator.methods) {
-			value = $element.data("rule-" + method.toLowerCase());
+			value = $element.data("rule" + method[0].toUpperCase() + method.substring(1).toLowerCase());
 			if ( value !== undefined ) {
 				rules[method] = value;
 			}


### PR DESCRIPTION
Hi Jörn

This change would amend the way the plug-in extracts data rules from using this technique:

``` javascript
$element.data("rule-number")
```

To this technique:

``` javascript
$element.data("ruleNumber")
```

I’m not sure if this pull request provides any significant value as it doesn’t fix anything.  I submit it as it brings jQuery Validate in line with the W3C HTML5 specification:

http://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes

jQuery fell into line with this in jQuery 1.6:

http://api.jquery.com/data/#data-html5

If you want jQuery Validate to continue to work with jQuery versions prior to 1.6 then you may want to reject this pull request.  Though on http://jqueryvalidation.org/ the earliest tested version listed is 1.6.4 which made me think it may make sense.

I’m not sure if there are plans to deprecate the “data with hyphens” style data extraction from jQuery.  If there are then it may make sense to merge this.  If not then it's your call, given this is not strictly fixing anything.

The existing tests pass with this change. 

All the best,
John
