### PR TITLE
Fix enumeration order of rules in the check() method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -120,7 +120,7 @@ $.extend($.fn, {
 	// http://jqueryvalidation.org/rules/
 	rules: function( command, argument ) {
 		var element = this[0];
-		var validator = $.data(element.form, "validator")
+		var validator = $.data(element.form, "validator");
 		if ( command ) {
 			var settings = validator.settings;
 			var staticRules = settings.rules;
@@ -161,14 +161,20 @@ $.extend($.fn, {
 		// make sure required is first and remote is last
 		var idx = 0;
 		var arr = new Array(validator.objectLength(data));
-		if ( data.required )
+		if ( data.required ) {
 			arr[idx++] = { method: 'required', parameters: data.required };
-		for ( prop in data ) {
-			if ( prop != 'required' && prop != 'remote')
-				arr[idx++] = { method: prop, parameters: data[prop] };
 		}
-		if ( data.remote )
+		for ( var prop in data ) {
+			if ( prop !== 'required' && prop !== 'remote') {
+				arr[idx++] = { method: prop, parameters: data[prop] };
+			}
+		}
+		if ( data.remote ) {
 			arr[idx] = { method: 'remote', parameters: data.remote };
+		}
+		if ( data.remote ) {
+			arr[idx] = { method: 'remote', parameters: data.remote };
+		}
 
 		return arr;
 	}
@@ -488,7 +494,7 @@ $.extend($.validator, {
 				}
 
 				// select only the first element for each name, and only those with rules specified
-				if ( this.name in rulesCache || $(this).rules().length ) {
+				if ( this.name in rulesCache || !$(this).rules().length ) {
 					return false;
 				}
 

--- a/test/rules.js
+++ b/test/rules.js
@@ -3,7 +3,7 @@ module("rules");
 test("rules() - internal - input", function() {
 	var element = $('#firstname');
 	var v = $('#testForm1').validate();
-	deepEqual( element.rules(), { required: true, minlength: 2 } );
+	deepEqual( element.rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 } ] );
 });
 
 test("rules(), ignore method:false", function() {
@@ -13,19 +13,19 @@ test("rules(), ignore method:false", function() {
 			firstname: { required: false, minlength: 2 }
 		}
 	});
-	deepEqual( element.rules(), { minlength: 2 } );
+	deepEqual( element.rules(), [ { method: "minlength", parameters: 2 } ] );
 });
 
 test("rules() HTML5 required (no value)", function() {
 	var element = $('#testForm11text1');
 	var v = $('#testForm11').validate();
-	deepEqual( element.rules(), { required: true } );
+	deepEqual( element.rules(), [ { method: "required", parameters: true } ] );
 });
 
 test("rules() - internal - select", function() {
 	var element = $('#meal');
 	var v = $('#testForm3').validate();
-	deepEqual( element.rules(), {required: true} );
+	deepEqual( element.rules(), [ { method: "required", parameters: true } ] );
 });
 
 test("rules() - external", function() {
@@ -35,7 +35,7 @@ test("rules() - external", function() {
 			action: {date: true, min: 5}
 		}
 	});
-	deepEqual( element.rules(), {date: true, min: 5} );
+	deepEqual( element.rules(), [ { method: "date", parameters: true }, { method: "min", parameters: 5 } ] );
 });
 
 test("rules() - external - complete form", function() {
@@ -62,7 +62,7 @@ test("rules() - external - complete form", function() {
 test("rules() - internal - input", function() {
 	var element = $('#form8input');
 	var v = $('#testForm8').validate();
-	deepEqual( element.rules(), {required: true, number: true, rangelength: [2, 8]});
+	deepEqual( element.rules(), [ { method: "required", parameters: true }, { method: "number", parameters: true}, { method: "rangelength", parameters: [2, 8] } ] );
 });
 
 test("rules(), merge min/max to range, minlength/maxlength to rangelength", function() {
@@ -79,9 +79,9 @@ test("rules(), merge min/max to range, minlength/maxlength to rangelength", func
 			}
 		}
 	});
-	deepEqual( $("#firstnamec").rules(), {range: [5, 12]});
+	deepEqual( $("#firstnamec").rules(), [ { method: "range", parameters: [5, 12] } ] );
 
-	deepEqual( $("#lastnamec").rules(), {rangelength: [2, 8]} );
+	deepEqual( $("#lastnamec").rules(), [ { method: "rangelength", parameters: [2, 8] } ] );
 	jQuery.validator.autoCreateRanges = false;
 });
 
@@ -91,7 +91,7 @@ test("rules(), guarantee that required is at front", function() {
 	$("#subformRequired").validate();
 	function flatRules(element) {
 		var result = [];
-		jQuery.each($(element).rules(), function(key, value) { result.push(key); });
+		jQuery.each($(element).rules(), function(key, value) { result.push(value.method); });
 		return result.join(" ");
 	}
 	equal( "required minlength", flatRules("#firstname") );
@@ -125,7 +125,7 @@ test("rules(), evaluate dynamic parameters", function() {
 			}
 		}
 	});
-	deepEqual( $("#firstnamec").rules(), {min:12});
+	deepEqual( $("#firstnamec").rules(), [ { method: "min", parameters: 12 } ] );
 });
 
 test("rules(), class and attribute combinations", function() {
@@ -145,16 +145,16 @@ test("rules(), class and attribute combinations", function() {
 			}
 		}
 	});
-	deepEqual( $("#v2-i1").rules(), { required: true });
-	deepEqual( $("#v2-i2").rules(), { required: true, email: true });
-	deepEqual( $("#v2-i3").rules(), { url: true });
-	deepEqual( $("#v2-i4").rules(), { required: true, minlength: 2 });
-	deepEqual( $("#v2-i5").rules(), { required: true, minlength: 2, maxlength: 5, customMethod1: "123" });
+	deepEqual( $("#v2-i1").rules(), [ { method: "required", parameters: true } ] );
+	deepEqual( $("#v2-i2").rules(), [ { method: "required", parameters: true }, { method: "email", parameters: true } ] );
+	deepEqual( $("#v2-i3").rules(), [ { method: "url", parameters: true } ] );
+	deepEqual( $("#v2-i4").rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 } ] );
+	deepEqual( $("#v2-i5").rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 }, { method: "maxlength", parameters: 5 }, { method: "customMethod1", parameters: "123" } ] );
 	jQuery.validator.autoCreateRanges = true;
-	deepEqual( $("#v2-i5").rules(), { required: true, customMethod1: "123", rangelength: [2, 5] });
-	deepEqual( $("#v2-i6").rules(), { required: true, customMethod2: true, rangelength: [2, 5] });
+	deepEqual( $("#v2-i5").rules(), [ { method: "required", parameters: true }, { method: "customMethod1", parameters: "123" }, { method: "rangelength", parameters: [2, 5] } ] );
+	deepEqual( $("#v2-i6").rules(), [ { method: "required", parameters: true }, { method: "customMethod2", parameters: true }, { method: "rangelength", parameters: [2, 5] } ] );
 	jQuery.validator.autoCreateRanges = false;
-	deepEqual( $("#v2-i7").rules(), { required: true, minlength: 2, customMethod: true });
+	deepEqual( $("#v2-i7").rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 }, { method: "customMethod", parameters: true } ] );
 
 	delete $.validator.methods.customMethod1;
 	delete $.validator.messages.customMethod1;
@@ -188,9 +188,9 @@ test("rules(), dependency checks", function() {
 	equal( 0, v.objectLength(rules) );
 
 	$("#firstnamec").val('ab');
-	deepEqual( $("#firstnamec").rules(), {min:5});
+	deepEqual( $("#firstnamec").rules(), [ { method: "min", parameters: 5 } ] );
 
-	deepEqual( $("#lastnamec").rules(), {max:12, email:true});
+	deepEqual( $("#lastnamec").rules(), [ { method: "max", parameters: 12 }, { method: "email", parameters: true } ] );
 });
 
 test("rules(), add and remove", function() {
@@ -199,16 +199,16 @@ test("rules(), add and remove", function() {
 	}, "");
 	$("#v2").validate();
 	var removedAttrs = $("#v2-i5").removeClass("required").removeAttrs("minlength maxlength");
-	deepEqual( $("#v2-i5").rules(), { customMethod1: "123" });
+	deepEqual( $("#v2-i5").rules(), [ { method: "customMethod1", parameters: "123" } ]);
 
 	$("#v2-i5").addClass("required").attr(removedAttrs);
-	deepEqual( $("#v2-i5").rules(), { required: true, minlength: 2, maxlength: 5, customMethod1: "123" });
+	deepEqual( $("#v2-i5").rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 }, { method: "maxlength", parameters: 5 }, { method: "customMethod1", parameters: "123" } ]);
 
 	$("#v2-i5").addClass("email").attr({min: 5});
-	deepEqual( $("#v2-i5").rules(), { required: true, email: true, minlength: 2, maxlength: 5, min: 5, customMethod1: "123" });
+	deepEqual( $("#v2-i5").rules(), [ { method: "required", parameters: true }, { method: "email", parameters: true }, { method: "minlength", parameters: 2 }, { method: "maxlength", parameters: 5 }, { method: "min", parameters: 5 }, { method: "customMethod1", parameters: "123" } ]);
 
 	$("#v2-i5").removeClass("required email").removeAttrs("minlength maxlength customMethod1 min");
-	deepEqual( $("#v2-i5").rules(), {});
+	deepEqual( $("#v2-i5").rules(), []);
 
 	delete $.validator.methods.customMethod1;
 	delete $.validator.messages.customMethod1;
@@ -220,35 +220,35 @@ test("rules(), add and remove static rules", function() {
 			firstname: "required date"
 		}
 	});
-	deepEqual( $("#firstnamec").rules(), { required: true, date: true } );
+	deepEqual( $("#firstnamec").rules(), [ { method: "required", parameters: true }, { method: "date", parameters: true } ] );
 
 	$("#firstnamec").rules("remove", "date");
-	deepEqual( $("#firstnamec").rules(), { required: true } );
+	deepEqual( $("#firstnamec").rules(), [ { method: "required", parameters: true } ] );
 	$("#firstnamec").rules("add", "email");
-	deepEqual( $("#firstnamec").rules(), { required: true, email: true } );
+	deepEqual( $("#firstnamec").rules(), [ { method: "required", parameters: true }, { method: "email", parameters: true } ] );
 
 	$("#firstnamec").rules("remove", "required");
-	deepEqual( $("#firstnamec").rules(), { email: true } );
+	deepEqual( $("#firstnamec").rules(), [ { method: "email", parameters: true } ] );
 
 	deepEqual( $("#firstnamec").rules("remove"), { email: true } );
-	deepEqual( $("#firstnamec").rules(), { } );
+	deepEqual( $("#firstnamec").rules(), [] );
 
 	$("#firstnamec").rules("add", "required email");
-	deepEqual( $("#firstnamec").rules(), { required: true, email: true } );
+	deepEqual( $("#firstnamec").rules(), [ { method: "required", parameters: true }, { method: "email", parameters: true } ] );
 
 
-	deepEqual( $("#lastnamec").rules(), {} );
+	deepEqual( $("#lastnamec").rules(), [] );
 	$("#lastnamec").rules("add", "required");
 	$("#lastnamec").rules("add", {
 		minlength: 2
 	});
-	deepEqual( $("#lastnamec").rules(), { required: true, minlength: 2 } );
+	deepEqual( $("#lastnamec").rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 } ] );
 
 
 	var removedRules = $("#lastnamec").rules("remove", "required email");
-	deepEqual( $("#lastnamec").rules(), { minlength: 2 } );
+	deepEqual( $("#lastnamec").rules(), [ { method: "minlength", parameters: 2 } ] );
 	$("#lastnamec").rules("add", removedRules);
-	deepEqual( $("#lastnamec").rules(), { required: true, minlength: 2 } );
+	deepEqual( $("#lastnamec").rules(), [ { method: "required", parameters: true }, { method: "minlength", parameters: 2 } ] );
 });
 
 test("rules(), add messages", function() {


### PR DESCRIPTION
Adding support for the placeholder attribute on text input elements for
browsers that do not support the attribute. In these cases treat the
value of the text field as empty if the value equals the placeholder

Update the handle() function that invokes the submitHandler so that it
returns the result of the submitHandler. This allows the submit event to
continue to propagate (which is required for jquery.unobtrusive-ajax to
function correctly)

The implementation of the 'remote' validation rule makes an async ajax
request to a remote server and does not execute any other rules after
that. As such any rules that end up after the remote rule will not be
checked (i.e. 'password' and custom rules). This tweak makes sure the
'remote' validation rule executes last and thereby all other validation
rules will execute. Also, in order to ensure the rules() method return a 
consistent order I updated it to return an array instead of an object.
