### PR TITLE
Added the ability to customize the fields to validate.

### DIFF
--- a/jquery.validate.js
+++ b/jquery.validate.js
@@ -222,6 +222,7 @@ $.extend($.validator, {
 		errorContainer: $([]),
 		errorLabelContainer: $([]),
 		onsubmit: true,
+    include: "input, select, textarea", 
 		ignore: ":hidden",
 		ignoreTitle: false,
 		onfocusin: function( element, event ) {
@@ -474,7 +475,7 @@ $.extend($.validator, {
 
 			// select all valid inputs inside the form (no submit or reset buttons)
 			return $(this.currentForm)
-			.find("input, select, textarea")
+      .find( this.settings.include )
 			.not(":submit, :reset, :image, [disabled]")
 			.not( this.settings.ignore )
 			.filter(function() {


### PR DESCRIPTION
Hey,

With this change,  you would have the flexibility to validate any fields that match your selector.  If you keep the selector the default, it would perform as it does today (by validating "input, select, textarea").  

I have a business case where I need to be able to validate some hidden fields.  I wasn't able to get away with using the this.settings.ignore setting because I would not want to validate a field that is not displayed.

I think that many people would benefit from this change.  It would add a little more customization to jquery.validate. If there's anything you would like me to change, please let me know.

Thanks,

Ryan
