### PR TITLE
Add advanced remote return value checking

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1158,16 +1158,17 @@ $.extend($.validator, {
 				dataType: "json",
 				data: data,
 				success: function( response ) {
+                    var valid = false;
                     validator.settings.messages[element.name].remote = previous.originalMessage;
                     if (!validator.settings.validators[element.name].remote) {
                         validator.settings.validators[element.name].remote = null;
                     }
                     if ( $.isFunction(validator.settings.validators[element.name].remote) ) {
-                        var valid = validator.settings.validators[element.name].remote(response);
+                        valid = validator.settings.validators[element.name].remote(response);
                         // Force use of defaultMessage in case of failure
                         response = null;
                     } else {
-                        var valid = response === true || response === "true";
+                        valid = response === true || response === "true";
                     }
                     if ( valid ) {
 						var submitted = validator.formSubmitted;


### PR DESCRIPTION
I had an API that wasn't able to return a "true" or "false" string for the remote validator. So I added a method to allow more advanced checking of a remote's response. It would be used like this:

`````` javascript
    $('.registration-form').validate({
        rules: {
            user_email: {
                required: true,
                email: true,
                // Use a standard remote object to initialize the call
                remote: {
                    url: "/the/url",
                    beforeSend: function() {
                        // Show a spinner
                    },
                    complete: function() {
                        // Hide the spinner
                    }
                }
            }
        },
        messages: {
            // The default error message will be used during failure
            user_email: { remote: "This email account already exists!" }
        },
        /* New functionality: This code will be executed in the success
         * method of jQuery's ajax call. It should return true or false
         * based on whatever criteria you need
         */
        validators: {
            user_email: {
                remote: function(response) {
                        if (response.complex_value meets your criteria) {
                            return true;
                        } else {
                            return false;
                        }
                    }
                }
            },
        }
});```
``````
