### PR TITLE
FIX to remove error class from elements with "depends" rule when rule does not apply anymore

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -904,6 +904,7 @@ $.extend($.validator, {
 	},
 
 	normalizeRules: function( rules, element ) {
+		var validator = $.data( element.form, "validator" );
 		// handle dependency check
 		$.each(rules, function( prop, val ) {
 			// ignore rule when param is explicitly false, eg. required:false
@@ -925,6 +926,9 @@ $.extend($.validator, {
 					rules[prop] = val.param !== undefined ? val.param : true;
 				} else {
 					delete rules[prop];
+					if ($( element ).hasClass( validator.settings.errorClass ) ) {
+						validator.settings.unhighlight.call( validator, element, validator.settings.errorClass, validator.settings.validClass );
+					}
 				}
 			}
 		});


### PR DESCRIPTION
Error class is not removed from elements with "depends" rules when rule does not apply anymore.

You can check what I mean looking at http://jsfiddle.net/NTvPM/. If you submit the form with checkbox checked both inputs go red. Next you uncheck the checkbox and submit again and second error message dissapears but the input still has red border because error class is still there.

I changed normalizeRules to call unhighlight if the rule is going to be deleted and the element has the error class assigned. Not sure if it's the best way to solve this.
