### PR TITLE
#697: removing wrong error message cache mechanism

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1131,9 +1131,7 @@ $.extend($.validator, {
 			}
 
 			var previous = this.previousValue(element);
-			if (!this.settings.messages[element.name] ) {
-				this.settings.messages[element.name] = {};
-			}
+			this.settings.messages[element.name] = {};
 			previous.originalMessage = this.settings.messages[element.name].remote;
 			this.settings.messages[element.name].remote = previous.message;
 


### PR DESCRIPTION
This cache mechanism is not necessary and it's not caching properly.
