### PR TITLE
Add missing dots to 'es' and 'es_AR' messages.

### DIFF
--- a/src/localization/messages_es.js
+++ b/src/localization/messages_es.js
@@ -6,7 +6,7 @@
 	$.extend($.validator.messages, {
 		required: "Este campo es obligatorio.",
 		remote: "Por favor, rellena este campo.",
-		email: "Por favor, escribe una dirección de correo válida",
+		email: "Por favor, escribe una dirección de correo válida.",
 		url: "Por favor, escribe una URL válida.",
 		date: "Por favor, escribe una fecha válida.",
 		dateISO: "Por favor, escribe una fecha (ISO) válida.",

--- a/src/localization/messages_es_AR.js
+++ b/src/localization/messages_es_AR.js
@@ -7,7 +7,7 @@
 	$.extend($.validator.messages, {
 		required: "Este campo es obligatorio.",
 		remote: "Por favor, completá este campo.",
-		email: "Por favor, escribí una dirección de correo válida",
+		email: "Por favor, escribí una dirección de correo válida.",
 		url: "Por favor, escribí una URL válida.",
 		date: "Por favor, escribí una fecha válida.",
 		dateISO: "Por favor, escribí una fecha (ISO) válida.",


### PR DESCRIPTION
When I created `messages_es_AR.js` I used `messages_es.js` as template, and there was a missing dot in one of the messages. This PR fixes both files.
