### PR TITLE
fix: showLabel() after label was hidden

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -679,7 +679,7 @@ $.extend($.validator, {
 			var label = this.errorsFor( element );
 			if ( label.length ) {
 				// refresh error/success class
-				label.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
+				label.removeClass( this.settings.validClass ).addClass( this.settings.errorClass ).show();
 				// replace message on existing label
 				label.html(message);
 			} else {


### PR DESCRIPTION
when calling showLabel() on label which was lately hidden, does not show the label.
This is because  label has style=display:none (.hide() in jquery), but showLabel() (in case already existing label) only set label text and add classes.
