### PR TITLE
fixed bug in RTM demo page

### DIFF
--- a/demo/milk/index.html
+++ b/demo/milk/index.html
@@ -19,7 +19,7 @@ $(document).ready(function() {
 				emails = ["glen@marketo.com", "george@bush.gov", "me@god.com", "aboutface@cooper.com", "steam@valve.com", "bill@gates.com"];
 			this.responseText = "true";
 			if ( $.inArray( email, emails ) !== -1 ) {
-				this.responseText = "That's already taken.";
+				this.responseText = "false";
 			}
 		},
 		responseTime: 500


### PR DESCRIPTION
The mockjax needs to return `"false"`, not an error message.  Only false is recognized as non-valid response.  The error-message is properly defined here: https://github.com/pconerly/jquery-validation/blob/56e704a903cc673a8965fe201658eb92a1e78bbd/demo/milk/index.html#L89
