### PR TITLE
Support elements without name attribute

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -487,7 +487,9 @@ $.extend($.validator, {
 					return false;
 				}
 
-				rulesCache[this.name] = true;
+				if ( this.name ) {
+					rulesCache[this.name] = true;
+				}
 				return true;
 			});
 		},


### PR DESCRIPTION
Seems like it should make sure <code>this.name</code> this not <code>""</code> or <code>undefined</code> before adding an item to the <code>rulesCache[]</code>. Otherwise, it will only validate the first element without a name and will skip subsequent elements.
