### PR TITLE
Triggering success on optional but have other successful validators

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -538,6 +538,9 @@ $.extend($.validator, {
 			element = this.validationTargetFor( this.clean( element ) );
 
 			var rules = $(element).rules();
+			var rulesCount = $.map( rules, function(n, i) {
+				return i;
+			}).length;
 			var dependencyMismatch = false;
 			var val = this.elementValue(element);
 			var result;
@@ -550,7 +553,7 @@ $.extend($.validator, {
 
 					// if a method indicates that the field is optional and therefore valid,
 					// don't mark it as valid when there are no other rules
-					if ( result === "dependency-mismatch" ) {
+					if ( result === "dependency-mismatch" && rulesCount === 1 ) {
 						dependencyMismatch = true;
 						continue;
 					}

--- a/test/test.js
+++ b/test/test.js
@@ -900,7 +900,8 @@ test("successlist", function() {
 	equal(0, v.successList.length);
 });
 
-test("success isn't called for optional elements", function() {
+
+test("success isn't called for optional elements with no other rules", function() {
 	expect(4);
 	equal( "", $("#firstname").removeAttr("data-rule-required").removeAttr("data-rule-minlength").val() );
 	$("#something").remove();
@@ -911,7 +912,7 @@ test("success isn't called for optional elements", function() {
 			ok( false, "don't call success for optional elements!" );
 		},
 		rules: {
-			firstname: "email"
+			firstname: { required: false }
 		}
 	});
 	equal( 0, $("#testForm1 label").size() );
@@ -920,6 +921,31 @@ test("success isn't called for optional elements", function() {
 	$("#firstname").valid();
 	equal( 0, $("#testForm1 label").size() );
 });
+
+test("success is called for optional elements with other rules", function() {
+	expect(1);
+
+	$.validator.addMethod("custom1", function() {
+		return true;
+	}, "");
+
+	var v = $("#testForm1clean").validate({
+		success: function() {
+			ok( true, "success called correctly!" );
+		},
+		rules: {
+			firstname: {
+				required: false,
+				custom1: true
+			}
+		}
+	});
+
+	$("#firstnamec").valid();
+
+	delete $.validator.methods.custom1;
+});
+
 
 test("success callback with element", function() {
 	expect(1);


### PR DESCRIPTION
Addresses issue #851. The comment in the code itself says "when there
are no other rules" but does nothing to enforce that comment.

This uses a jquery map function to count object keys, as Object.keys
does not work in < IE9. Taken from http://stackoverflow.com/questions/5533192/how-to-get-object-length-in-jquery
