### PR TITLE
phoneUS: Add N11 exclusions

### DIFF
--- a/src/additional/phoneUS.js
+++ b/src/additional/phoneUS.js
@@ -17,5 +17,5 @@
 jQuery.validator.addMethod("phoneUS", function(phone_number, element) {
 	phone_number = phone_number.replace(/\s+/g, "");
 	return this.optional(element) || phone_number.length > 9 &&
-		phone_number.match(/^(\+?1-?)?(\([2-9]\d{2}\)|[2-9]\d{2})-?[2-9]\d{2}-?\d{4}$/);
+		phone_number.match(/^(\+?1-?)?(\([2-9]([02-9]\d|1[02-9])\)|[2-9]([02-9]\d|1[02-9]))-?[2-9]([02-9]\d|1[02-9])-?\d{4}$/);
 }, "Please specify a valid phone number");

--- a/test/methods.js
+++ b/test/methods.js
@@ -549,8 +549,11 @@ test("phone (us)", function() {
 	ok( method( "1(212)-999-2345" ), "Valid US phone number" );
 	ok( method( "212 999 2344" ), "Valid US phone number" );
 	ok( method( "212-999-0983" ), "Valid US phone number" );
-	ok(!method( "111-123-5434" ), "Invalid US phone number" );
-	ok(!method( "212 123 4567" ), "Invalid US phone number" );
+	ok(!method( "111-123-5434" ), "Invalid US phone number. Area Code cannot start with 1" );
+	ok(!method( "212 123 4567" ), "Invalid US phone number. NXX cannot start with 1" );
+	ok(!method( "234-911-5678" ), "Invalid US phone number, because the exchange code cannot be in the form N11" );
+	ok(!method( "911-333-5678" ), "Invalid US phone number, because the area code cannot be in the form N11" );
+	ok(method( "234-912-5678" ), "Valid US phone number" );
 });
 
 test("phoneUK", function() {


### PR DESCRIPTION
Numbers like 911 and 411 cannot be used for area or exchange codes.
https://en.wikipedia.org/wiki/NANPA#Numbering_system
