### PR TITLE
Add semi-colon before function invocation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,7 @@
  *   http://www.opensource.org/licenses/mit-license.php
  */
 
-(function($) {
+;(function($) {
 
 $.extend($.fn, {
 	// http://jqueryvalidation.org/validate/


### PR DESCRIPTION
The semi-colon at the beginning of the plugin is a good practice. Serves as a safety precaution when concatenate many Js files.
