### PR TITLE
Problem with not running validation when onfocusout is called.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -236,7 +236,7 @@ $.extend($.validator, {
 			}
 		},
 		onfocusout: function( element, event ) {
-			if ( !this.checkable(element) && (element.name in this.submitted || !this.optional(element)) ) {
+			if ( !this.checkable(element) ) {
 				this.element(element);
 			}
 		},
@@ -769,7 +769,7 @@ $.extend($.validator, {
 
 		optional: function( element ) {
 			var val = this.elementValue(element);
-			return !$.validator.methods.required.call(this, val, element);
+			return !$.validator.methods.required.call(this, val, element)  && "dependency-mismatch";
 		},
 
 		startRequest: function( element ) {


### PR DESCRIPTION
There is a problem with plugin not validating fields when focus is out. This was reported by some people to work on "random" basis.

The problem is on line 239. The check fails because `this.optional` returns string `"dependency-mismatch"` and the whole if statement returns wrong bool result. Sometimes it works, because the field is in `this.submited` array

The whole method `optional` should be probably changed.
This change fix problem for me, but I'm not sure about other use cases.

I'm not knee deep in the code.
