### PR TITLE
Only add 'for' value if errorElement is a label

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -685,9 +685,13 @@ $.extend($.validator, {
 			} else {
 				// create label
 				label = $("<" + this.settings.errorElement + ">")
-					.attr("for", this.idOrName(element))
 					.addClass(this.settings.errorClass)
 					.html(message || "");
+
+				if ( /label/.test( this.settings.errorElement ) ) {
+					label.attr( "for", this.idOrName( element ) );
+				}
+
 				if ( this.settings.wrapper ) {
 					// make sure the element is visible, even in IE
 					// actually showing the wrapped element is handled elsewhere

--- a/test/index.html
+++ b/test/index.html
@@ -343,6 +343,11 @@
 				<input id="bypassSubmitWithNoValidate1" type="submit" formnovalidate value="bypass1"/>
 				<input id="bypassSubmitWithNoValidate2" type="submit" formnovalidate="formnovalidate" value="bypass2"/>
 		</form>
+
+		<form id="errorElement">
+			<input type="text" data-rule-required="true" id="errorElementInput" />
+			<label for="errorElementInput">error for default errorElement</label>
+		</form>
 	</div>
 
 </body>

--- a/test/test.js
+++ b/test/test.js
@@ -1549,3 +1549,15 @@ test("Min and Max number set by attributes less", function() {
 	equal( label.text(), "Please enter a value greater than or equal to 50.", "Correct error label" );
 });
 
+test( "Non-label errorElement label doesn't add 'for'", function() {
+	var form = $( "#errorElement" );
+	var errorElement = "span";
+	var validator = form.validate({
+		errorElement: errorElement
+	});
+
+	form.valid();
+	var replacementLabel = form.find( errorElement + ".error" );
+
+	ok( !replacementLabel.attr( "for" ), "No 'for' attribute" );
+});


### PR DESCRIPTION
A 'for' on other types causes problems for screen readers, and is not valid HTML
