### PR TITLE
Fix incorrect behavior for required attribute in ie8.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -864,7 +864,8 @@ $.extend($.validator, {
 				value = $element.get(0).getAttribute(method);
 				// Some browsers return an empty string for the required attribute
 				// and non-HTML5 browsers might have required="" markup
-				if ( value === "" ) {
+				var isAttributeExist = $element.is('['+method+']');
+				if (isAttributeExist && value === "") {
 					value = true;
 				}
 				// force non-HTML5 browsers to return bool


### PR DESCRIPTION
In case when we have custom method and attribute for it, "requiredif"
(on example) that depend of any condition (we use unobtrusive library
for asp.net project with custom attributes for model), ie8 think that we
always should have required for it and when we comparing for required
attribute in core js file, it is always true even it is not exist on
element in dom . Fix contains additional check for attribute exist. Reproduced only in ie8.
