### PR TITLE
Misc additional features

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -616,6 +616,20 @@ $.extend($.validator, {
 			var m = this.settings.messages[name];
 			return m && (m.constructor === String ? m : m[method]);
 		},
+		
+		//Retrieve the message attached to class rules
+		classMessage: function(element, method) {
+			var messages = {};
+			var classes = $(element).attr('class');
+			if ( classes ) {
+				$.each(classes.split(' '), function() {
+					if ($.validator.classMessageSettings[this]) {
+						$.extend(messages, $.validator.classMessageSettings[this]);
+					}
+				});
+			}
+			return messages[method];
+		},
 
 		// return the first defined argument, allowing empty strings
 		findDefined: function() {
@@ -629,6 +643,7 @@ $.extend($.validator, {
 
 		defaultMessage: function( element, method ) {
 			return this.findDefined(
+				this.classMessage( element, method ),
 				this.customMessage( element.name, method ),
 				this.customDataMessage( element, method ),
 				// title is never undefined, so handle empty string as undefined
@@ -878,6 +893,20 @@ $.extend($.validator, {
 			});
 		}
 		return rules;
+	},
+	
+	/*
+	* Support for messages defined by class
+	*/
+	
+	classMessageSettings: {},
+	
+	addClassMessages: function(className, messages) {
+		if ( className.constructor === String ) {
+			this.classMessageSettings[className] = messages;
+		} else {
+			$.extend(this.classMessageSettings, className);
+		}
 	},
 	
 	/*


### PR DESCRIPTION
Sorry thought I could do these in individual pull requests, but apparently not.
- Explicit Message parameters (a5876f1)
  I find it very restrictive that the rule's parameters are used for the message and there is no way to specify overt message parameters. There are many custom rules that need to specify different message parameters than rule parameters. For example, in our application we frequently have origin and destination geography, and we created a custom rule to validate that the minimum amount of geography was specified, and set the message to "Please specify geography information for the {0}," where the parameter is 'origin' or 'geography', but the parameter of the rule was a selector for the container containing all the relevant fields. 
- Less than/Greater than/Less than equal/Greater than equal (68fc4f0)
  A few additional useful rules. These are dependent on having explicit message parameters, otherwise their messages will not make sense.
- Support for class-based messages (8ed9382)
  I figure if you can specify a class-based rule, it makes sense to also allow a custom message for that class-based rule by class, just as you can for a custom static rule. For example, if I want to override the custom message for a rule, but I need it to be class-based so I can clone it with jQuery, there was no way of doing that.
