### PR TITLE
Add errorAttribute setting. Fixes #966.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -222,6 +222,7 @@ $.extend($.validator, {
 		errorClass: "error",
 		validClass: "valid",
 		errorElement: "label",
+		errorAttribute: "for",
 		focusInvalid: true,
 		errorContainer: $([]),
 		errorLabelContainer: $([]),
@@ -699,7 +700,7 @@ $.extend($.validator, {
 			} else {
 				// create label
 				label = $("<" + this.settings.errorElement + ">")
-					.attr("for", this.idOrName(element))
+					.attr(this.settings.errorAttribute, this.idOrName(element))
 					.addClass(this.settings.errorClass)
 					.html(message || "");
 				if ( this.settings.wrapper ) {
@@ -728,8 +729,9 @@ $.extend($.validator, {
 
 		errorsFor: function( element ) {
 			var name = this.idOrName(element);
+			var errorAttribute = this.settings.errorAttribute;
 			return this.errors().filter(function() {
-				return $(this).attr("for") === name;
+				return $(this).attr(errorAttribute) === name;
 			});
 		},
 

--- a/test/index.html
+++ b/test/index.html
@@ -356,6 +356,10 @@
 			<input type="text" name="ariaRequiredData" id="ariaRequiredData" data-rule-required="true" />
 			<input type="text" name="ariaRequiredClass" id="ariaRequiredClass" class="required" />
 		</form>
+
+		<form id="customErrorAttribute">
+			<input type="text" name="errorAttributeDataFor" id="errorAttributeDataFor" class="required" />
+		</form>
 	</div>
 
 </body>

--- a/test/test.js
+++ b/test/test.js
@@ -1549,3 +1549,32 @@ test("Min and Max number set by attributes less", function() {
 	equal( label.text(), "Please enter a value greater than or equal to 50.", "Correct error label" );
 });
 
+
+test("Using a custom errorElement and errorAttribute", function() {
+	var form = $('#customErrorAttribute');
+	var field = $('#errorAttributeDataFor');
+
+	form.validate({
+		errorElement: 'span',
+		errorAttribute: 'data-for'
+	});
+
+	form.get(0).reset();
+	field.valid();
+
+	var label = $('#customErrorAttribute span');
+	equal(label.text(), "This field is required.", "Correct error label");
+
+	// One issue with not using an errorAttribute at all is that errors will stack multiple times
+	// So let's test that if we validate the field again, there is still only one error message shown
+	field.valid();
+
+	label = $('#customErrorAttribute span');
+	equal(label.length, 1, "Only one error shown");
+
+	field.val('Test Value');
+	field.valid();
+
+	label = $('#customErrorAttribute span');
+	equal(label.css('display'), "none", "Label should be hidden when valid");
+});


### PR DESCRIPTION
Adds an `errorAttribute` setting that complements the existing `errorElement` setting. You can use these together to create an error element like `<span data-for="form_field_id">Your error message here.</span>`.

This would also require an update to the documentation on http://jqueryvalidation.org/documentation/, but I don't see anywhere that I can update that.
