### PR TITLE
Quickfix for issue #1002.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1223,6 +1223,7 @@ $.extend($.validator, {
 						errors[element.name] = previous.message = $.isFunction(message) ? message(value) : message;
 						validator.invalid[element.name] = true;
 						validator.showErrors(errors);
+						validator.submitted[element.name] = message;
 					}
 					previous.valid = valid;
 					validator.stopRequest(element, valid);


### PR DESCRIPTION
Adding the field name to the `submitted` map causes it to be considered for processing in the default `onkeyup` event handler.
Although to me it seems that calling `formatAndAdd` here could be better.
