### PR TITLE
Allow attributes to have a value of zero (eg min='0')

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -908,7 +908,7 @@ $.extend($.validator, {
 				value = Number(value);
 			}
 
-			if ( value ) {
+			if ( value || value === 0 ) {
 				rules[method] = value;
 			} else if ( type === method && type !== "range" ) {
 				// exception: the jquery validate 'range' method

--- a/test/index.html
+++ b/test/index.html
@@ -334,6 +334,10 @@
 			<input type="number" id="rangeNumberInvalidGreater" name="rangeNumberInvalidGreater" min="50" max="200" value="1000"/>
 			<input type="number" id="rangeNumberInvalidLess" name="rangeNumberInvalidLess" min="50" max="200" value="6"/>
 
+			<input type="number" id="rangeMinZeroInvalidLess" name="rangeMinZeroInvalidLess" min="0" value="-1"/>
+			<input type="number" id="rangeMinZeroValidEqual" name="rangeMinZeroValidEqual" min="0" value="0"/>
+			<input type="number" id="rangeMinZeroValidGreater" name="rangeMinZeroValidGreater" min="0" value="1"/>
+
 		</form>
 		<form id="rangeMinDateValid">
 			<input type="date" id="minDateValid" name="minDateValid" min="2012-11-21" value="2012-12-21"/>

--- a/test/test.js
+++ b/test/test.js
@@ -1669,3 +1669,41 @@ test("Min and Max number set by attributes less", function() {
 	equal( label.text(), "Please enter a value greater than or equal to 50.", "Correct error label" );
 });
 
+test("Rules allowed to have a value of zero invalid", function() {
+	var form = $("#ranges"),
+		name = $("#rangeMinZeroInvalidLess"),
+		label;
+
+	form.validate();
+	form.get(0).reset();
+	name.valid();
+
+	label = $("#ranges label");
+	equal( label.text(), "Please enter a value greater than or equal to 0.", "Correct error label" );
+});
+
+test("Rules allowed to have a value of zero valid equal", function() {
+	var form = $("#ranges"),
+		name = $("#rangeMinZeroValidEqual"),
+		label;
+
+	form.validate();
+	form.get(0).reset();
+	name.valid();
+
+	label = $("#ranges label");
+	equal( label.text(), "", "Correct error label" );
+});
+
+test("Rules allowed to have a value of zero valid greater", function() {
+	var form = $("#ranges"),
+		name = $("#rangeMinZeroValidGreater"),
+		label;
+
+	form.validate();
+	form.get(0).reset();
+	name.valid();
+
+	label = $("#ranges label");
+	equal( label.text(), "", "Correct error label" );
+});


### PR DESCRIPTION
I've found that HTML rule attributes that have a value of `0` are not applied, for example, `min="0"`.  If `min="0"` is specified, the user could still enter `-1` in the `<input>` field.

This is because in `attributeRules()` there is a truthy test on the attribute's value before the rule is applied, so anything equal to `0` will be ignored.

To fix this, we also check for `value === 0`.  If so, the rule is applied.

Tests were added to validate this.
