### PR TITLE
Error list containing validation rule method 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -667,7 +667,7 @@ $.extend($.validator, {
 			this.errorList.push({
 				message: message,
 				element: element,
-				method : rule.method
+				method: rule.method
 			});
 
 			this.errorMap[element.name] = message;


### PR DESCRIPTION
Add "method" field to errorlist entry so we can check what specific kind of validation rule was broken (for example "required" or "ranglelength") and apply corresponding behavior. For example, sometimes we might want user to be able to submit form with empty required fields- and save it as a draft, showing him a warning. For that scenario we have to find a way to differ error messages based on validation rule they were raised from. Adding  "method" field will solve this problem.
