### PR TITLE
API FIX Use aria-describedby and default error element changed to span

### DIFF
--- a/demo/errors-within-labels.html
+++ b/demo/errors-within-labels.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Test for jQuery validate() plugin</title>
+
+<link rel="stylesheet" media="screen" href="css/screen.css" />
+
+<script src="../lib/jquery.js"></script>
+<script src="../dist/jquery.validate.js"></script>
+
+<style>
+.cmxform fieldset p label span.error { color: red; }
+form.cmxform { width: 30em; }
+form.cmxform label {
+	width: auto;
+	display: block;
+	float: none;
+}
+</style>
+
+<script>
+// only for demo purposes
+$.validator.setDefaults({
+	submitHandler: function() {
+		alert("submitted!");
+	}
+});
+
+$().ready(function() {
+	// validate the form when it is submitted
+	var validator = $("#form1").validate({
+		errorPlacement: function(error, element) {
+			// Append error within linked label
+			$( element )
+				.closest( "form" )
+					.find( "label[for='" + element.attr( "id" ) + "']" )
+						.append( error );
+		},
+		errorElement: "span",
+		messages: {
+			user: {
+				required: " (required)",
+				minlength: " (must be at least 3 characters)"
+			},
+			password: {
+				required: " (required)",
+				minlength: " (must be between 5 and 12 characters)",
+				maxlength: " (must be between 5 and 12 characters)"
+			}
+		}
+	});
+
+	$(".cancel").click(function() {
+		validator.resetForm();
+	});
+});
+</script>
+
+</head>
+<body>
+
+<h1 id="banner"><a href="http://bassistance.de/jquery-plugins/jquery-plugin-validation/">jQuery Validation Plugin</a> Demo</h1>
+<div id="main">
+	
+	<p>Errors use spans placed within existing label element</p>
+
+	<form method="get" class="cmxform" id="form1" action="">
+		<fieldset>
+			<legend>Login Form</legend>
+			<p>
+				<label for="user">Username</label>
+				<input id="user" name="user" required minlength="3" />
+			</p>
+			<p>
+				<label for="password">Password</label>
+				<input id="password" type="password" maxlength="12" name="password" required minlength="5" />
+			</p>
+			<p>
+				<input class="submit" type="submit" value="Login"/>
+			</p>
+		</fieldset>
+	</form>
+
+	<a href="index.html">Back to main page</a>
+
+</div>
+
+
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -215,6 +215,8 @@
 		</li>
 		<li><a href="jquerymobile.html">jQuery Mobile Form Validation</a>
 		</li>
+		<li><a href="errors-within-labels.html">Displaying Errors within Field Labels</a>
+		</li>
 	</ul>
 	<h3>Real-world examples</h3>
 	<ul>

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,6 @@
-(function($) {
+(function( $ ) {
 
-$.extend($.fn, {
+$.extend( $.fn, {
 	// http://jqueryvalidation.org/validate/
 	validate: function( options ) {
 
@@ -13,7 +13,7 @@ $.extend($.fn, {
 		}
 
 		// check if a validator for this form was already created
-		var validator = $.data( this[0], "validator" );
+		var validator = $.data( this[ 0 ], "validator" );
 		if ( validator ) {
 			return validator;
 		}
@@ -21,8 +21,8 @@ $.extend($.fn, {
 		// Add novalidate tag if HTML5.
 		this.attr( "novalidate", "novalidate" );
 
-		validator = new $.validator( options, this[0] );
-		$.data( this[0], "validator", validator );
+		validator = new $.validator( options, this[ 0 ] );
+		$.data( this[ 0 ], "validator", validator );
 
 		if ( validator.settings.onsubmit ) {
 
@@ -31,12 +31,12 @@ $.extend($.fn, {
 					validator.submitButton = event.target;
 				}
 				// allow suppressing validation by adding a cancel class to the submit button
-				if ( $(event.target).hasClass("cancel") ) {
+				if ( $( event.target ).hasClass( "cancel" ) ) {
 					validator.cancelSubmit = true;
 				}
 
 				// allow suppressing validation by adding the html5 formnovalidate attribute to the submit button
-				if ( $(event.target).attr("formnovalidate") !== undefined ) {
+				if ( $( event.target ).attr( "formnovalidate" ) !== undefined ) {
 					validator.cancelSubmit = true;
 				}
 			});
@@ -52,7 +52,10 @@ $.extend($.fn, {
 					if ( validator.settings.submitHandler ) {
 						if ( validator.submitButton ) {
 							// insert a hidden input as a replacement for the missing submit button
-							hidden = $("<input type='hidden'/>").attr("name", validator.submitButton.name).val( $(validator.submitButton).val() ).appendTo(validator.currentForm);
+							hidden = $( "<input type='hidden'/>" )
+								.attr( "name", validator.submitButton.name )
+								.val( $( validator.submitButton ).val() )
+								.appendTo( validator.currentForm );
 						}
 						validator.settings.submitHandler.call( validator, validator.currentForm, event );
 						if ( validator.submitButton ) {
@@ -88,13 +91,13 @@ $.extend($.fn, {
 	valid: function() {
 		var valid, validator;
 
-		if ( $(this[0]).is("form")) {
+		if ( $( this[ 0 ] ).is( "form" ) ) {
 			valid = this.validate().form();
 		} else {
 			valid = true;
-			validator = $(this[0].form).validate();
-			this.each(function() {
-				valid = validator.element(this) && valid;
+			validator = $( this[ 0 ].form ).validate();
+			this.each( function() {
+				valid = validator.element( this ) && valid;
 			});
 		}
 		return valid;
@@ -103,42 +106,42 @@ $.extend($.fn, {
 	removeAttrs: function( attributes ) {
 		var result = {},
 			$element = this;
-		$.each(attributes.split(/\s/), function( index, value ) {
-			result[value] = $element.attr(value);
-			$element.removeAttr(value);
+		$.each( attributes.split( /\s/ ), function( index, value ) {
+			result[ value ] = $element.attr( value );
+			$element.removeAttr( value );
 		});
 		return result;
 	},
 	// http://jqueryvalidation.org/rules/
 	rules: function( command, argument ) {
-		var element = this[0],
+		var element = this[ 0 ],
 			settings, staticRules, existingRules, data, param, filtered;
 
 		if ( command ) {
-			settings = $.data(element.form, "validator").settings;
+			settings = $.data( element.form, "validator" ).settings;
 			staticRules = settings.rules;
-			existingRules = $.validator.staticRules(element);
-			switch (command) {
+			existingRules = $.validator.staticRules( element );
+			switch ( command ) {
 			case "add":
-				$.extend(existingRules, $.validator.normalizeRule(argument));
+				$.extend( existingRules, $.validator.normalizeRule( argument ) );
 				// remove messages from rules, but allow them to be set separately
 				delete existingRules.messages;
-				staticRules[element.name] = existingRules;
+				staticRules[ element.name ] = existingRules;
 				if ( argument.messages ) {
-					settings.messages[element.name] = $.extend( settings.messages[element.name], argument.messages );
+					settings.messages[ element.name ] = $.extend( settings.messages[ element.name ], argument.messages );
 				}
 				break;
 			case "remove":
 				if ( !argument ) {
-					delete staticRules[element.name];
+					delete staticRules[ element.name ];
 					return existingRules;
 				}
 				filtered = {};
-				$.each(argument.split(/\s/), function( index, method ) {
-					filtered[method] = existingRules[method];
-					delete existingRules[method];
+				$.each( argument.split( /\s/ ), function( index, method ) {
+					filtered[ method ] = existingRules[ method ];
+					delete existingRules[ method ];
 					if ( method === "required" ) {
-						$(element).removeAttr("aria-required");
+						$( element ).removeAttr( "aria-required" );
 					}
 				});
 				return filtered;
@@ -148,18 +151,18 @@ $.extend($.fn, {
 		data = $.validator.normalizeRules(
 		$.extend(
 			{},
-			$.validator.classRules(element),
-			$.validator.attributeRules(element),
-			$.validator.dataRules(element),
-			$.validator.staticRules(element)
-		), element);
+			$.validator.classRules( element ),
+			$.validator.attributeRules( element ),
+			$.validator.dataRules( element ),
+			$.validator.staticRules( element )
+		), element );
 
 		// make sure required is at front
 		if ( data.required ) {
 			param = data.required;
 			delete data.required;
-			data = $.extend({ required: param }, data );
-			$(element).attr( "aria-required", "true" );
+			data = $.extend( { required: param }, data );
+			$( element ).attr( "aria-required", "true" );
 		}
 
 		// make sure remote is at back
@@ -174,13 +177,13 @@ $.extend($.fn, {
 });
 
 // Custom selectors
-$.extend($.expr[":"], {
+$.extend( $.expr[ ":" ], {
 	// http://jqueryvalidation.org/blank-selector/
-	blank: function( a ) { return !$.trim("" + $(a).val()); },
+	blank: function( a ) { return !$.trim( "" + $( a ).val() ); },
 	// http://jqueryvalidation.org/filled-selector/
-	filled: function( a ) { return !!$.trim("" + $(a).val()); },
+	filled: function( a ) { return !!$.trim( "" + $( a ).val() ); },
 	// http://jqueryvalidation.org/unchecked-selector/
-	unchecked: function( a ) { return !$(a).prop("checked"); }
+	unchecked: function( a ) { return !$( a ).prop( "checked" ); }
 });
 
 // constructor for validator
@@ -194,26 +197,26 @@ $.validator = function( options, form ) {
 $.validator.format = function( source, params ) {
 	if ( arguments.length === 1 ) {
 		return function() {
-			var args = $.makeArray(arguments);
-			args.unshift(source);
+			var args = $.makeArray( arguments );
+			args.unshift( source );
 			return $.validator.format.apply( this, args );
 		};
 	}
 	if ( arguments.length > 2 && params.constructor !== Array  ) {
-		params = $.makeArray(arguments).slice(1);
+		params = $.makeArray( arguments ).slice( 1 );
 	}
 	if ( params.constructor !== Array ) {
 		params = [ params ];
 	}
-	$.each(params, function( i, n ) {
-		source = source.replace( new RegExp("\\{" + i + "\\}", "g"), function() {
+	$.each( params, function( i, n ) {
+		source = source.replace( new RegExp( "\\{" + i + "\\}", "g" ), function() {
 			return n;
 		});
 	});
 	return source;
 };
 
-$.extend($.validator, {
+$.extend( $.validator, {
 
 	defaults: {
 		messages: {},
@@ -223,8 +226,8 @@ $.extend($.validator, {
 		validClass: "valid",
 		errorElement: "label",
 		focusInvalid: true,
-		errorContainer: $([]),
-		errorLabelContainer: $([]),
+		errorContainer: $( [] ),
+		errorLabelContainer: $( [] ),
 		onsubmit: true,
 		ignore: ":hidden",
 		ignoreTitle: false,
@@ -236,43 +239,43 @@ $.extend($.validator, {
 				if ( this.settings.unhighlight ) {
 					this.settings.unhighlight.call( this, element, this.settings.errorClass, this.settings.validClass );
 				}
-				this.addWrapper(this.errorsFor(element)).hide();
+				this.addWrapper( this.errorsFor( element ) ).hide();
 			}
 		},
 		onfocusout: function( element ) {
-			if ( !this.checkable(element) && (element.name in this.submitted || !this.optional(element)) ) {
-				this.element(element);
+			if ( !this.checkable( element ) && ( element.name in this.submitted || !this.optional( element ) ) ) {
+				this.element( element );
 			}
 		},
 		onkeyup: function( element, event ) {
-			if ( event.which === 9 && this.elementValue(element) === "" ) {
+			if ( event.which === 9 && this.elementValue( element ) === "" ) {
 				return;
 			} else if ( element.name in this.submitted || element === this.lastElement ) {
-				this.element(element);
+				this.element( element );
 			}
 		},
 		onclick: function( element ) {
 			// click on selects, radiobuttons and checkboxes
 			if ( element.name in this.submitted ) {
-				this.element(element);
+				this.element( element );
 
 			// or option elements, check parent select in that case
 			} else if ( element.parentNode.name in this.submitted ) {
-				this.element(element.parentNode);
+				this.element( element.parentNode );
 			}
 		},
 		highlight: function( element, errorClass, validClass ) {
 			if ( element.type === "radio" ) {
-				this.findByName(element.name).addClass(errorClass).removeClass(validClass);
+				this.findByName( element.name ).addClass( errorClass ).removeClass( validClass );
 			} else {
-				$(element).addClass(errorClass).removeClass(validClass);
+				$( element ).addClass( errorClass ).removeClass( validClass );
 			}
 		},
 		unhighlight: function( element, errorClass, validClass ) {
 			if ( element.type === "radio" ) {
-				this.findByName(element.name).removeClass(errorClass).addClass(validClass);
+				this.findByName( element.name ).removeClass( errorClass ).addClass( validClass );
 			} else {
-				$(element).removeClass(errorClass).addClass(validClass);
+				$( element ).removeClass( errorClass ).addClass( validClass );
 			}
 		}
 	},
@@ -288,17 +291,17 @@ $.extend($.validator, {
 		email: "Please enter a valid email address.",
 		url: "Please enter a valid URL.",
 		date: "Please enter a valid date.",
-		dateISO: "Please enter a valid date (ISO).",
+		dateISO: "Please enter a valid date ( ISO ).",
 		number: "Please enter a valid number.",
 		digits: "Please enter only digits.",
 		creditcard: "Please enter a valid credit card number.",
 		equalTo: "Please enter the same value again.",
-		maxlength: $.validator.format("Please enter no more than {0} characters."),
-		minlength: $.validator.format("Please enter at least {0} characters."),
-		rangelength: $.validator.format("Please enter a value between {0} and {1} characters long."),
-		range: $.validator.format("Please enter a value between {0} and {1}."),
-		max: $.validator.format("Please enter a value less than or equal to {0}."),
-		min: $.validator.format("Please enter a value greater than or equal to {0}.")
+		maxlength: $.validator.format( "Please enter no more than {0} characters." ),
+		minlength: $.validator.format( "Please enter at least {0} characters." ),
+		rangelength: $.validator.format( "Please enter a value between {0} and {1} characters long." ),
+		range: $.validator.format( "Please enter a value between {0} and {1}." ),
+		max: $.validator.format( "Please enter a value less than or equal to {0}." ),
+		min: $.validator.format( "Please enter a value greater than or equal to {0}." )
 	},
 
 	autoCreateRanges: false,
@@ -306,9 +309,9 @@ $.extend($.validator, {
 	prototype: {
 
 		init: function() {
-			this.labelContainer = $(this.settings.errorLabelContainer);
-			this.errorContext = this.labelContainer.length && this.labelContainer || $(this.currentForm);
-			this.containers = $(this.settings.errorContainer).add( this.settings.errorLabelContainer );
+			this.labelContainer = $( this.settings.errorLabelContainer );
+			this.errorContext = this.labelContainer.length && this.labelContainer || $( this.currentForm );
+			this.containers = $( this.settings.errorContainer ).add( this.settings.errorLabelContainer );
 			this.submitted = {};
 			this.valueCache = {};
 			this.pendingRequest = 0;
@@ -316,31 +319,31 @@ $.extend($.validator, {
 			this.invalid = {};
 			this.reset();
 
-			var groups = (this.groups = {}),
+			var groups = ( this.groups = {} ),
 				rules;
-			$.each(this.settings.groups, function( key, value ) {
+			$.each( this.settings.groups, function( key, value ) {
 				if ( typeof value === "string" ) {
-					value = value.split(/\s/);
+					value = value.split( /\s/ );
 				}
-				$.each(value, function( index, name ) {
-					groups[name] = key;
+				$.each( value, function( index, name ) {
+					groups[ name ] = key;
 				});
 			});
 			rules = this.settings.rules;
-			$.each(rules, function( key, value ) {
-				rules[key] = $.validator.normalizeRule(value);
+			$.each( rules, function( key, value ) {
+				rules[ key ] = $.validator.normalizeRule( value );
 			});
 
-			function delegate(event) {
-				var validator = $.data(this[0].form, "validator"),
-					eventType = "on" + event.type.replace(/^validate/, ""),
+			function delegate( event ) {
+				var validator = $.data( this[ 0 ].form, "validator" ),
+					eventType = "on" + event.type.replace( /^validate/, "" ),
 					settings = validator.settings;
-				if ( settings[eventType] && !this.is( settings.ignore ) ) {
-					settings[eventType].call(validator, this[0], event);
+				if ( settings[ eventType ] && !this.is( settings.ignore ) ) {
+					settings[ eventType ].call( validator, this[ 0 ], event );
 				}
 			}
-			$(this.currentForm)
-				.validateDelegate(":text, [type='password'], [type='file'], select, textarea, " +
+			$( this.currentForm )
+				.validateDelegate( ":text, [type='password'], [type='file'], select, textarea, " +
 					"[type='number'], [type='search'] ,[type='tel'], [type='url'], " +
 					"[type='email'], [type='datetime'], [type='date'], [type='month'], " +
 					"[type='week'], [type='time'], [type='datetime-local'], " +
@@ -351,21 +354,21 @@ $.extend($.validator, {
 				.validateDelegate("select, option", "click", delegate);
 
 			if ( this.settings.invalidHandler ) {
-				$(this.currentForm).bind("invalid-form.validate", this.settings.invalidHandler);
+				$( this.currentForm ).bind( "invalid-form.validate", this.settings.invalidHandler );
 			}
 
 			// Add aria-required to any Static/Data/Class required fields before first validation
 			// Screen readers require this attribute to be present before the initial submission http://www.w3.org/TR/WCAG-TECHS/ARIA2.html
-			$(this.currentForm).find("[required], [data-rule-required], .required").attr("aria-required", "true");
+			$( this.currentForm ).find( "[required], [data-rule-required], .required" ).attr( "aria-required", "true" );
 		},
 
 		// http://jqueryvalidation.org/Validator.form/
 		form: function() {
 			this.checkForm();
-			$.extend(this.submitted, this.errorMap);
-			this.invalid = $.extend({}, this.errorMap);
+			$.extend( this.submitted, this.errorMap );
+			this.invalid = $.extend({}, this.errorMap );
 			if ( !this.valid() ) {
-				$(this.currentForm).triggerHandler("invalid-form", [ this ]);
+				$( this.currentForm ).triggerHandler( "invalid-form", [ this ]);
 			}
 			this.showErrors();
 			return this.valid();
@@ -373,8 +376,8 @@ $.extend($.validator, {
 
 		checkForm: function() {
 			this.prepareForm();
-			for ( var i = 0, elements = (this.currentElements = this.elements()); elements[i]; i++ ) {
-				this.check( elements[i] );
+			for ( var i = 0, elements = ( this.currentElements = this.elements() ); elements[ i ]; i++ ) {
+				this.check( elements[ i ] );
 			}
 			return this.valid();
 		},
@@ -394,10 +397,10 @@ $.extend($.validator, {
 				this.currentElements = $( checkElement );
 
 				result = this.check( checkElement ) !== false;
-				if (result) {
-					delete this.invalid[checkElement.name];
+				if ( result ) {
+					delete this.invalid[ checkElement.name ];
 				} else {
-					this.invalid[checkElement.name] = true;
+					this.invalid[ checkElement.name ] = true;
 				}
 			}
 			// Add aria-invalid status for screen readers
@@ -419,13 +422,13 @@ $.extend($.validator, {
 				this.errorList = [];
 				for ( var name in errors ) {
 					this.errorList.push({
-						message: errors[name],
-						element: this.findByName(name)[0]
+						message: errors[ name ],
+						element: this.findByName( name )[ 0 ]
 					});
 				}
 				// remove items from success list
 				this.successList = $.grep( this.successList, function( element ) {
-					return !(element.name in errors);
+					return !( element.name in errors );
 				});
 			}
 			if ( this.settings.showErrors ) {
@@ -438,7 +441,7 @@ $.extend($.validator, {
 		// http://jqueryvalidation.org/Validator.resetForm/
 		resetForm: function() {
 			if ( $.fn.resetForm ) {
-				$(this.currentForm).resetForm();
+				$( this.currentForm ).resetForm();
 			}
 			this.submitted = {};
 			this.lastElement = null;
@@ -451,7 +454,7 @@ $.extend($.validator, {
 		},
 
 		numberOfInvalids: function() {
-			return this.objectLength(this.invalid);
+			return this.objectLength( this.invalid );
 		},
 
 		objectLength: function( obj ) {
@@ -479,12 +482,12 @@ $.extend($.validator, {
 		focusInvalid: function() {
 			if ( this.settings.focusInvalid ) {
 				try {
-					$(this.findLastActive() || this.errorList.length && this.errorList[0].element || [])
-					.filter(":visible")
+					$( this.findLastActive() || this.errorList.length && this.errorList[ 0 ].element || [])
+					.filter( ":visible" )
 					.focus()
 					// manually trigger focusin event; without it, focusin handler isn't called, findLastActive won't have anything to find
-					.trigger("focusin");
-				} catch(e) {
+					.trigger( "focusin" );
+				} catch( e ) {
 					// ignore IE throwing errors when focusing hidden elements
 				}
 			}
@@ -492,7 +495,7 @@ $.extend($.validator, {
 
 		findLastActive: function() {
 			var lastActive = this.lastActive;
-			return lastActive && $.grep(this.errorList, function( n ) {
+			return lastActive && $.grep( this.errorList, function( n ) {
 				return n.element.name === lastActive.name;
 			}).length === 1 && lastActive;
 		},
@@ -502,41 +505,41 @@ $.extend($.validator, {
 				rulesCache = {};
 
 			// select all valid inputs inside the form (no submit or reset buttons)
-			return $(this.currentForm)
-			.find("input, select, textarea")
-			.not(":submit, :reset, :image, [disabled]")
+			return $( this.currentForm )
+			.find( "input, select, textarea" )
+			.not( ":submit, :reset, :image, [disabled]" )
 			.not( this.settings.ignore )
-			.filter(function() {
+			.filter( function() {
 				if ( !this.name && validator.settings.debug && window.console ) {
-					console.error( "%o has no name assigned", this);
+					console.error( "%o has no name assigned", this );
 				}
 
 				// select only the first element for each name, and only those with rules specified
-				if ( this.name in rulesCache || !validator.objectLength($(this).rules()) ) {
+				if ( this.name in rulesCache || !validator.objectLength( $( this ).rules() ) ) {
 					return false;
 				}
 
-				rulesCache[this.name] = true;
+				rulesCache[ this.name ] = true;
 				return true;
 			});
 		},
 
 		clean: function( selector ) {
-			return $(selector)[0];
+			return $( selector )[ 0 ];
 		},
 
 		errors: function() {
-			var errorClass = this.settings.errorClass.split(" ").join(".");
-			return $(this.settings.errorElement + "." + errorClass, this.errorContext);
+			var errorClass = this.settings.errorClass.split( " " ).join( "." );
+			return $( this.settings.errorElement + "." + errorClass, this.errorContext );
 		},
 
 		reset: function() {
 			this.successList = [];
 			this.errorList = [];
 			this.errorMap = {};
-			this.toShow = $([]);
-			this.toHide = $([]);
-			this.currentElements = $([]);
+			this.toShow = $( [] );
+			this.toHide = $( [] );
+			this.currentElements = $( [] );
 		},
 
 		prepareForm: function() {
@@ -546,23 +549,23 @@ $.extend($.validator, {
 
 		prepareElement: function( element ) {
 			this.reset();
-			this.toHide = this.errorsFor(element);
+			this.toHide = this.errorsFor( element );
 		},
 
 		elementValue: function( element ) {
 			var val,
-				$element = $(element),
+				$element = $( element ),
 				type = element.type;
 
 			if ( type === "radio" || type === "checkbox" ) {
-				return $("input[name='" + element.name + "']:checked").val();
+				return $( "input[name='" + element.name + "']:checked" ).val();
 			} else if ( type === "number" && typeof element.validity !== "undefined" ) {
 				return element.validity.badInput ? false : $element.val();
 			}
 
 			val = $element.val();
 			if ( typeof val === "string" ) {
-				return val.replace(/\r/g, "");
+				return val.replace(/\r/g, "" );
 			}
 			return val;
 		},
@@ -570,19 +573,19 @@ $.extend($.validator, {
 		check: function( element ) {
 			element = this.validationTargetFor( this.clean( element ) );
 
-			var rules = $(element).rules(),
-				rulesCount = $.map( rules, function(n, i) {
+			var rules = $( element ).rules(),
+				rulesCount = $.map( rules, function( n, i ) {
 					return i;
 				}).length,
 				dependencyMismatch = false,
-				val = this.elementValue(element),
+				val = this.elementValue( element ),
 				result, method, rule;
 
-			for (method in rules ) {
-				rule = { method: method, parameters: rules[method] };
+			for ( method in rules ) {
+				rule = { method: method, parameters: rules[ method ] };
 				try {
 
-					result = $.validator.methods[method].call( this, val, element, rule.parameters );
+					result = $.validator.methods[ method ].call( this, val, element, rule.parameters );
 
 					// if a method indicates that the field is optional and therefore valid,
 					// don't mark it as valid when there are no other rules
@@ -593,7 +596,7 @@ $.extend($.validator, {
 					dependencyMismatch = false;
 
 					if ( result === "pending" ) {
-						this.toHide = this.toHide.not( this.errorsFor(element) );
+						this.toHide = this.toHide.not( this.errorsFor( element ) );
 						return;
 					}
 
@@ -601,7 +604,7 @@ $.extend($.validator, {
 						this.formatAndAdd( element, rule );
 						return false;
 					}
-				} catch(e) {
+				} catch( e ) {
 					if ( this.settings.debug && window.console ) {
 						console.log( "Exception occurred when checking element " + element.id + ", check the '" + rule.method + "' method.", e );
 					}
@@ -611,8 +614,8 @@ $.extend($.validator, {
 			if ( dependencyMismatch ) {
 				return;
 			}
-			if ( this.objectLength(rules) ) {
-				this.successList.push(element);
+			if ( this.objectLength( rules ) ) {
+				this.successList.push( element );
 			}
 			return true;
 		},
@@ -622,20 +625,20 @@ $.extend($.validator, {
 		// return the generic message if present and no method specific message is present
 		customDataMessage: function( element, method ) {
 			return $( element ).data( "msg" + method.charAt( 0 ).toUpperCase() +
-				method.substring( 1 ).toLowerCase() ) || $( element ).data("msg");
+				method.substring( 1 ).toLowerCase() ) || $( element ).data( "msg" );
 		},
 
 		// return the custom message for the given element name and validation method
 		customMessage: function( name, method ) {
-			var m = this.settings.messages[name];
-			return m && (m.constructor === String ? m : m[method]);
+			var m = this.settings.messages[ name ];
+			return m && ( m.constructor === String ? m : m[ method ]);
 		},
 
 		// return the first defined argument, allowing empty strings
 		findDefined: function() {
-			for (var i = 0; i < arguments.length; i++) {
-				if ( arguments[i] !== undefined ) {
-					return arguments[i];
+			for ( var i = 0; i < arguments.length; i++) {
+				if ( arguments[ i ] !== undefined ) {
+					return arguments[ i ];
 				}
 			}
 			return undefined;
@@ -647,7 +650,7 @@ $.extend($.validator, {
 				this.customDataMessage( element, method ),
 				// title is never undefined, so handle empty string as undefined
 				!this.settings.ignoreTitle && element.title || undefined,
-				$.validator.messages[method],
+				$.validator.messages[ method ],
 				"<strong>Warning: No message defined for " + element.name + "</strong>"
 			);
 		},
@@ -656,9 +659,9 @@ $.extend($.validator, {
 			var message = this.defaultMessage( element, rule.method ),
 				theregex = /\$?\{(\d+)\}/g;
 			if ( typeof message === "function" ) {
-				message = message.call(this, rule.parameters, element);
-			} else if (theregex.test(message)) {
-				message = $.validator.format(message.replace(theregex, "{$1}"), rule.parameters);
+				message = message.call( this, rule.parameters, element );
+			} else if ( theregex.test( message ) ) {
+				message = $.validator.format( message.replace( theregex, "{$1}" ), rule.parameters );
 			}
 			this.errorList.push({
 				message: message,
@@ -666,8 +669,8 @@ $.extend($.validator, {
 				method: rule.method
 			});
 
-			this.errorMap[element.name] = message;
-			this.submitted[element.name] = message;
+			this.errorMap[ element.name ] = message;
+			this.submitted[ element.name ] = message;
 		},
 
 		addWrapper: function( toToggle ) {
@@ -679,8 +682,8 @@ $.extend($.validator, {
 
 		defaultShowErrors: function() {
 			var i, elements, error;
-			for ( i = 0; this.errorList[i]; i++ ) {
-				error = this.errorList[i];
+			for ( i = 0; this.errorList[ i ]; i++ ) {
+				error = this.errorList[ i ];
 				if ( this.settings.highlight ) {
 					this.settings.highlight.call( this, error.element, this.settings.errorClass, this.settings.validClass );
 				}
@@ -690,13 +693,13 @@ $.extend($.validator, {
 				this.toShow = this.toShow.add( this.containers );
 			}
 			if ( this.settings.success ) {
-				for ( i = 0; this.successList[i]; i++ ) {
-					this.showLabel( this.successList[i] );
+				for ( i = 0; this.successList[ i ]; i++ ) {
+					this.showLabel( this.successList[ i ] );
 				}
 			}
 			if ( this.settings.unhighlight ) {
-				for ( i = 0, elements = this.validElements(); elements[i]; i++ ) {
-					this.settings.unhighlight.call( this, elements[i], this.settings.errorClass, this.settings.validClass );
+				for ( i = 0, elements = this.validElements(); elements[ i ]; i++ ) {
+					this.settings.unhighlight.call( this, elements[ i ], this.settings.errorClass, this.settings.validClass );
 				}
 			}
 			this.toHide = this.toHide.not( this.toShow );
@@ -705,93 +708,126 @@ $.extend($.validator, {
 		},
 
 		validElements: function() {
-			return this.currentElements.not(this.invalidElements());
+			return this.currentElements.not( this.invalidElements() );
 		},
 
 		invalidElements: function() {
-			return $(this.errorList).map(function() {
+			return $( this.errorList ).map(function() {
 				return this.element;
 			});
 		},
 
 		showLabel: function( element, message ) {
-			var label = this.errorsFor( element );
-			if ( label.length ) {
+			var place, group,
+				error = this.errorsFor( element ),
+				elementID = this.idOrName( element );
+			if ( error.length ) {
 				// refresh error/success class
-				label.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
+				error.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
 				// replace message on existing label
-				label.html(message);
+				error.html( message );
 			} else {
-				// create label
-				label = $("<" + this.settings.errorElement + ">")
-					.attr("for", this.idOrName(element))
-					.addClass(this.settings.errorClass)
-					.html(message || "");
+				// create error element
+				error = $( "<" + this.settings.errorElement + ">" )
+					.attr( "id", elementID + "-error" )
+					.addClass( this.settings.errorClass )
+					.html( message || "" );
+			
+				// Maintain reference to the element to be placed into the DOM
+				place = error;
 				if ( this.settings.wrapper ) {
 					// make sure the element is visible, even in IE
 					// actually showing the wrapped element is handled elsewhere
-					label = label.hide().show().wrap("<" + this.settings.wrapper + "/>").parent();
+					place = error.hide().show().wrap( "<" + this.settings.wrapper + "/>" ).parent();
 				}
-				if ( !this.labelContainer.append(label).length ) {
-					if ( this.settings.errorPlacement ) {
-						this.settings.errorPlacement(label, $(element) );
-					} else {
-						label.insertAfter(element);
+				if ( this.labelContainer.length ) {
+					this.labelContainer.append( place );
+				} else if ( this.settings.errorPlacement ) {
+					this.settings.errorPlacement( place, $( element ) );
+				} else {
+					place.insertAfter( element );
+				}
+				
+				// Link error back to the element
+				if ( error.is( "label" ) ) {
+					// If the error is a label, then associate using 'for'
+					error.attr( "for", elementID );
+				} else if ( error.parents( "label[for='" + elementID + "']" ).length === 0 ) {
+					// If the element is not a child of an associated label, then it's necessary
+					// to explicitly apply aria-describedby
+					$( element ).attr( "aria-describedby", error.attr( "id" ) );
+				
+					// If this element is grouped, then assign to all elements in the same group
+					group = this.groups[ element.name ];
+					if ( group ) {
+						$.each( this.groups, function( name, testgroup ) {
+							if ( testgroup === group ) {
+								$( "[name='" + name + "']", this.currentForm )
+									.attr( "aria-describedby", error.attr( "id" ) );
+							}
+						});
 					}
 				}
 			}
 			if ( !message && this.settings.success ) {
-				label.text("");
+				error.text( "" );
 				if ( typeof this.settings.success === "string" ) {
-					label.addClass( this.settings.success );
+					error.addClass( this.settings.success );
 				} else {
-					this.settings.success( label, element );
+					this.settings.success( error, element );
 				}
 			}
-			this.toShow = this.toShow.add(label);
+			this.toShow = this.toShow.add( error );
 		},
 
 		errorsFor: function( element ) {
-			var name = this.idOrName(element);
-			return this.errors().filter(function() {
-				return $(this).attr("for") === name;
-			});
+			var name = this.idOrName( element ),
+				describer = $( element ).attr( "aria-describedby" );
+			if ( describer ) {
+				// aria-describedby should directly reference the error element
+				return $( "#" + describer, this.errorContext );
+			} else {
+				// If no describer is used then errors are either associated labels, or children of non-error labels
+				return this
+					.errors()
+					.filter( "label[for='" + name + "'], label[for='" + name + "'] *" );
+			}
 		},
 
 		idOrName: function( element ) {
-			return this.groups[element.name] || (this.checkable(element) ? element.name : element.id || element.name);
+			return this.groups[ element.name ] || ( this.checkable( element ) ? element.name : element.id || element.name );
 		},
 
 		validationTargetFor: function( element ) {
 			// if radio/checkbox, validate first element in group instead
-			if ( this.checkable(element) ) {
-				element = this.findByName( element.name ).not(this.settings.ignore)[0];
+			if ( this.checkable( element ) ) {
+				element = this.findByName( element.name ).not( this.settings.ignore )[ 0 ];
 			}
 			return element;
 		},
 
 		checkable: function( element ) {
-			return (/radio|checkbox/i).test(element.type);
+			return ( /radio|checkbox/i ).test( element.type );
 		},
 
 		findByName: function( name ) {
-			return $(this.currentForm).find("[name='" + name + "']");
+			return $( this.currentForm ).find( "[name='" + name + "']" );
 		},
 
 		getLength: function( value, element ) {
 			switch ( element.nodeName.toLowerCase() ) {
 			case "select":
-				return $("option:selected", element).length;
+				return $( "option:selected", element ).length;
 			case "input":
-				if ( this.checkable( element) ) {
-					return this.findByName(element.name).filter(":checked").length;
+				if ( this.checkable( element ) ) {
+					return this.findByName( element.name ).filter( ":checked" ).length;
 				}
 			}
 			return value.length;
 		},
 
 		depend: function( param, element ) {
-			return this.dependTypes[typeof param] ? this.dependTypes[typeof param](param, element) : true;
+			return this.dependTypes[typeof param] ? this.dependTypes[typeof param]( param, element ) : true;
 		},
 
 		dependTypes: {
@@ -799,22 +835,22 @@ $.extend($.validator, {
 				return param;
 			},
 			"string": function( param, element ) {
-				return !!$(param, element.form).length;
+				return !!$( param, element.form ).length;
 			},
 			"function": function( param, element ) {
-				return param(element);
+				return param( element );
 			}
 		},
 
 		optional: function( element ) {
-			var val = this.elementValue(element);
-			return !$.validator.methods.required.call(this, val, element) && "dependency-mismatch";
+			var val = this.elementValue( element );
+			return !$.validator.methods.required.call( this, val, element ) && "dependency-mismatch";
 		},
 
 		startRequest: function( element ) {
-			if ( !this.pending[element.name] ) {
+			if ( !this.pending[ element.name ] ) {
 				this.pendingRequest++;
-				this.pending[element.name] = true;
+				this.pending[ element.name ] = true;
 			}
 		},
 
@@ -824,18 +860,18 @@ $.extend($.validator, {
 			if ( this.pendingRequest < 0 ) {
 				this.pendingRequest = 0;
 			}
-			delete this.pending[element.name];
+			delete this.pending[ element.name ];
 			if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() ) {
-				$(this.currentForm).submit();
+				$( this.currentForm ).submit();
 				this.formSubmitted = false;
-			} else if (!valid && this.pendingRequest === 0 && this.formSubmitted) {
-				$(this.currentForm).triggerHandler("invalid-form", [ this ]);
+			} else if (!valid && this.pendingRequest === 0 && this.formSubmitted ) {
+				$( this.currentForm ).triggerHandler( "invalid-form", [ this ]);
 				this.formSubmitted = false;
 			}
 		},
 
 		previousValue: function( element ) {
-			return $.data(element, "previousValue") || $.data(element, "previousValue", {
+			return $.data( element, "previousValue" ) || $.data( element, "previousValue", {
 				old: null,
 				valid: true,
 				message: this.defaultMessage( element, "remote" )
@@ -857,20 +893,20 @@ $.extend($.validator, {
 
 	addClassRules: function( className, rules ) {
 		if ( className.constructor === String ) {
-			this.classRuleSettings[className] = rules;
+			this.classRuleSettings[ className ] = rules;
 		} else {
-			$.extend(this.classRuleSettings, className);
+			$.extend( this.classRuleSettings, className );
 		}
 	},
 
 	classRules: function( element ) {
 		var rules = {},
-			classes = $(element).attr("class");
+			classes = $( element ).attr( "class" );
 
 		if ( classes ) {
-			$.each(classes.split(" "), function() {
+			$.each( classes.split( " " ), function() {
 				if ( this in $.validator.classRuleSettings ) {
-					$.extend(rules, $.validator.classRuleSettings[this]);
+					$.extend( rules, $.validator.classRuleSettings[ this ]);
 				}
 			});
 		}
@@ -879,15 +915,15 @@ $.extend($.validator, {
 
 	attributeRules: function( element ) {
 		var rules = {},
-			$element = $(element),
-			type = element.getAttribute("type"),
+			$element = $( element ),
+			type = element.getAttribute( "type" ),
 			method, value;
 
-		for (method in $.validator.methods) {
+		for ( method in $.validator.methods ) {
 
 			// support for <input required> in both html5 and older browsers
 			if ( method === "required" ) {
-				value = element.getAttribute(method);
+				value = element.getAttribute( method );
 				// Some browsers return an empty string for the required attribute
 				// and non-HTML5 browsers might have required="" markup
 				if ( value === "" ) {
@@ -896,26 +932,26 @@ $.extend($.validator, {
 				// force non-HTML5 browsers to return bool
 				value = !!value;
 			} else {
-				value = $element.attr(method);
+				value = $element.attr( method );
 			}
 
 			// convert the value to a number for number inputs, and for text for backwards compability
 			// allows type="date" and others to be compared as strings
 			if ( /min|max/.test( method ) && ( type === null || /number|range|text/.test( type ) ) ) {
-				value = Number(value);
+				value = Number( value );
 			}
 
 			if ( value || value === 0 ) {
-				rules[method] = value;
+				rules[ method ] = value;
 			} else if ( type === method && type !== "range" ) {
 				// exception: the jquery validate 'range' method
 				// does not test for the html5 'range' type
-				rules[method] = true;
+				rules[ method ] = true;
 			}
 		}
 
-		// maxlength may be returned as -1, 2147483647 (IE) and 524288 (safari) for text inputs
-		if ( rules.maxlength && /-1|2147483647|524288/.test(rules.maxlength) ) {
+		// maxlength may be returned as -1, 2147483647 ( IE ) and 524288 ( safari ) for text inputs
+		if ( rules.maxlength && /-1|2147483647|524288/.test( rules.maxlength ) ) {
 			delete rules.maxlength;
 		}
 
@@ -936,59 +972,59 @@ $.extend($.validator, {
 
 	staticRules: function( element ) {
 		var rules = {},
-			validator = $.data(element.form, "validator");
+			validator = $.data( element.form, "validator" );
 
 		if ( validator.settings.rules ) {
-			rules = $.validator.normalizeRule(validator.settings.rules[element.name]) || {};
+			rules = $.validator.normalizeRule( validator.settings.rules[ element.name ] ) || {};
 		}
 		return rules;
 	},
 
 	normalizeRules: function( rules, element ) {
 		// handle dependency check
-		$.each(rules, function( prop, val ) {
+		$.each( rules, function( prop, val ) {
 			// ignore rule when param is explicitly false, eg. required:false
 			if ( val === false ) {
-				delete rules[prop];
+				delete rules[ prop ];
 				return;
 			}
 			if ( val.param || val.depends ) {
 				var keepRule = true;
-				switch (typeof val.depends) {
+				switch ( typeof val.depends ) {
 				case "string":
-					keepRule = !!$(val.depends, element.form).length;
+					keepRule = !!$( val.depends, element.form ).length;
 					break;
 				case "function":
-					keepRule = val.depends.call(element, element);
+					keepRule = val.depends.call( element, element );
 					break;
 				}
 				if ( keepRule ) {
-					rules[prop] = val.param !== undefined ? val.param : true;
+					rules[ prop ] = val.param !== undefined ? val.param : true;
 				} else {
-					delete rules[prop];
+					delete rules[ prop ];
 				}
 			}
 		});
 
 		// evaluate parameters
-		$.each(rules, function( rule, parameter ) {
-			rules[rule] = $.isFunction(parameter) ? parameter(element) : parameter;
+		$.each( rules, function( rule, parameter ) {
+			rules[ rule ] = $.isFunction( parameter ) ? parameter( element ) : parameter;
 		});
 
 		// clean number parameters
 		$.each([ "minlength", "maxlength" ], function() {
-			if ( rules[this] ) {
-				rules[this] = Number(rules[this]);
+			if ( rules[ this ] ) {
+				rules[ this ] = Number( rules[ this ] );
 			}
 		});
 		$.each([ "rangelength", "range" ], function() {
 			var parts;
-			if ( rules[this] ) {
-				if ( $.isArray(rules[this]) ) {
-					rules[this] = [ Number(rules[this][0]), Number(rules[this][1]) ];
-				} else if ( typeof rules[this] === "string" ) {
-					parts = rules[this].replace(/[\[\]]/g, "").split(/[\s,]+/);
-					rules[this] = [ Number(parts[0]), Number(parts[1]) ];
+			if ( rules[ this ] ) {
+				if ( $.isArray( rules[ this ] ) ) {
+					rules[ this ] = [ Number( rules[ this ][ 0 ]), Number( rules[ this ][ 1 ] ) ];
+				} else if ( typeof rules[ this ] === "string" ) {
+					parts = rules[ this ].replace(/[\[\]]/g, "" ).split( /[\s,]+/ );
+					rules[ this ] = [ Number( parts[ 0 ]), Number( parts[ 1 ] ) ];
 				}
 			}
 		});
@@ -1014,8 +1050,8 @@ $.extend($.validator, {
 	normalizeRule: function( data ) {
 		if ( typeof data === "string" ) {
 			var transformed = {};
-			$.each(data.split(/\s/), function() {
-				transformed[this] = true;
+			$.each( data.split( /\s/ ), function() {
+				transformed[ this ] = true;
 			});
 			data = transformed;
 		}
@@ -1024,10 +1060,10 @@ $.extend($.validator, {
 
 	// http://jqueryvalidation.org/jQuery.validator.addMethod/
 	addMethod: function( name, method, message ) {
-		$.validator.methods[name] = method;
-		$.validator.messages[name] = message !== undefined ? message : $.validator.messages[name];
+		$.validator.methods[ name ] = method;
+		$.validator.messages[ name ] = message !== undefined ? message : $.validator.messages[ name ];
 		if ( method.length < 3 ) {
-			$.validator.addClassRules(name, $.validator.normalizeRule(name));
+			$.validator.addClassRules( name, $.validator.normalizeRule( name ) );
 		}
 	},
 
@@ -1036,18 +1072,18 @@ $.extend($.validator, {
 		// http://jqueryvalidation.org/required-method/
 		required: function( value, element, param ) {
 			// check if dependency is met
-			if ( !this.depend(param, element) ) {
+			if ( !this.depend( param, element ) ) {
 				return "dependency-mismatch";
 			}
 			if ( element.nodeName.toLowerCase() === "select" ) {
 				// could be an array for select-multiple or a string, both are fine this way
-				var val = $(element).val();
+				var val = $( element ).val();
 				return val && val.length > 0;
 			}
-			if ( this.checkable(element) ) {
-				return this.getLength(value, element) > 0;
+			if ( this.checkable( element ) ) {
+				return this.getLength( value, element ) > 0;
 			}
-			return $.trim(value).length > 0;
+			return $.trim( value ).length > 0;
 		},
 
 		// http://jqueryvalidation.org/email-method/
@@ -1056,43 +1092,43 @@ $.extend($.validator, {
 			// Retrieved 2014-01-14
 			// If you have a problem with this implementation, report a bug against the above spec
 			// Or use custom methods to implement your own email validation
-			return this.optional(element) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(value);
+			return this.optional( element ) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test( value );
 		},
 
 		// http://jqueryvalidation.org/url-method/
 		url: function( value, element ) {
 			// contributed by Scott Gonzalez: http://projects.scottsplayground.com/iri/
-			return this.optional(element) || /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(value);
+			return this.optional( element ) || /^(https?|s?ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test( value );
 		},
 
 		// http://jqueryvalidation.org/date-method/
 		date: function( value, element ) {
-			return this.optional(element) || !/Invalid|NaN/.test(new Date(value).toString());
+			return this.optional( element ) || !/Invalid|NaN/.test( new Date( value ).toString() );
 		},
 
 		// http://jqueryvalidation.org/dateISO-method/
 		dateISO: function( value, element ) {
-			return this.optional(element) || /^\d{4}[\/\-]\d{1,2}[\/\-]\d{1,2}$/.test(value);
+			return this.optional( element ) || /^\d{4}[\/\-]\d{1,2}[\/\-]\d{1,2}$/.test( value );
 		},
 
 		// http://jqueryvalidation.org/number-method/
 		number: function( value, element ) {
-			return this.optional(element) || /^-?(?:\d+|\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/.test(value);
+			return this.optional( element ) || /^-?(?:\d+|\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/.test( value );
 		},
 
 		// http://jqueryvalidation.org/digits-method/
 		digits: function( value, element ) {
-			return this.optional(element) || /^\d+$/.test(value);
+			return this.optional( element ) || /^\d+$/.test( value );
 		},
 
 		// http://jqueryvalidation.org/creditcard-method/
 		// based on http://en.wikipedia.org/wiki/Luhn/
 		creditcard: function( value, element ) {
-			if ( this.optional(element) ) {
+			if ( this.optional( element ) ) {
 				return "dependency-mismatch";
 			}
 			// accept only spaces, digits and dashes
-			if ( /[^0-9 \-]+/.test(value) ) {
+			if ( /[^0-9 \-]+/.test( value ) ) {
 				return false;
 			}
 			var nCheck = 0,
@@ -1100,7 +1136,7 @@ $.extend($.validator, {
 				bEven = false,
 				n, cDigit;
 
-			value = value.replace(/\D/g, "");
+			value = value.replace( /\D/g, "" );
 
 			// Basing min and max length on
 			// http://developer.ean.com/general_info/Valid_Credit_Card_Types
@@ -1109,10 +1145,10 @@ $.extend($.validator, {
 			}
 
 			for ( n = value.length - 1; n >= 0; n--) {
-				cDigit = value.charAt(n);
-				nDigit = parseInt(cDigit, 10);
+				cDigit = value.charAt( n );
+				nDigit = parseInt( cDigit, 10 );
 				if ( bEven ) {
-					if ( (nDigit *= 2) > 9 ) {
+					if ( ( nDigit *= 2 ) > 9 ) {
 						nDigit -= 9;
 					}
 				}
@@ -1120,50 +1156,50 @@ $.extend($.validator, {
 				bEven = !bEven;
 			}
 
-			return (nCheck % 10) === 0;
+			return ( nCheck % 10 ) === 0;
 		},
 
 		// http://jqueryvalidation.org/minlength-method/
 		minlength: function( value, element, param ) {
-			var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
-			return this.optional(element) || length >= param;
+			var length = $.isArray( value ) ? value.length : this.getLength( $.trim( value ), element );
+			return this.optional( element ) || length >= param;
 		},
 
 		// http://jqueryvalidation.org/maxlength-method/
 		maxlength: function( value, element, param ) {
-			var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
-			return this.optional(element) || length <= param;
+			var length = $.isArray( value ) ? value.length : this.getLength( $.trim( value ), element );
+			return this.optional( element ) || length <= param;
 		},
 
 		// http://jqueryvalidation.org/rangelength-method/
 		rangelength: function( value, element, param ) {
-			var length = $.isArray( value ) ? value.length : this.getLength($.trim(value), element);
-			return this.optional(element) || ( length >= param[0] && length <= param[1] );
+			var length = $.isArray( value ) ? value.length : this.getLength( $.trim( value ), element );
+			return this.optional( element ) || ( length >= param[ 0 ] && length <= param[ 1 ] );
 		},
 
 		// http://jqueryvalidation.org/min-method/
 		min: function( value, element, param ) {
-			return this.optional(element) || value >= param;
+			return this.optional( element ) || value >= param;
 		},
 
 		// http://jqueryvalidation.org/max-method/
 		max: function( value, element, param ) {
-			return this.optional(element) || value <= param;
+			return this.optional( element ) || value <= param;
 		},
 
 		// http://jqueryvalidation.org/range-method/
 		range: function( value, element, param ) {
-			return this.optional(element) || ( value >= param[0] && value <= param[1] );
+			return this.optional( element ) || ( value >= param[ 0 ] && value <= param[ 1 ] );
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/
 		equalTo: function( value, element, param ) {
 			// bind to the blur event of the target in order to revalidate whenever the target field is updated
 			// TODO find a way to bind the event just once, avoiding the unbind-rebind overhead
-			var target = $(param);
+			var target = $( param );
 			if ( this.settings.onfocusout ) {
-				target.unbind(".validate-equalTo").bind("blur.validate-equalTo", function() {
-					$(element).valid();
+				target.unbind( ".validate-equalTo" ).bind( "blur.validate-equalTo", function() {
+					$( element ).valid();
 				});
 			}
 			return value === target.val();
@@ -1171,18 +1207,18 @@ $.extend($.validator, {
 
 		// http://jqueryvalidation.org/remote-method/
 		remote: function( value, element, param ) {
-			if ( this.optional(element) ) {
+			if ( this.optional( element ) ) {
 				return "dependency-mismatch";
 			}
 
-			var previous = this.previousValue(element),
+			var previous = this.previousValue( element ),
 				validator, data;
 
-			if (!this.settings.messages[element.name] ) {
-				this.settings.messages[element.name] = {};
+			if (!this.settings.messages[ element.name ] ) {
+				this.settings.messages[ element.name ] = {};
 			}
-			previous.originalMessage = this.settings.messages[element.name].remote;
-			this.settings.messages[element.name].remote = previous.message;
+			previous.originalMessage = this.settings.messages[ element.name ].remote;
+			this.settings.messages[ element.name ].remote = previous.message;
 
 			param = typeof param === "string" && { url: param } || param;
 
@@ -1192,10 +1228,10 @@ $.extend($.validator, {
 
 			previous.old = value;
 			validator = this;
-			this.startRequest(element);
+			this.startRequest( element );
 			data = {};
-			data[element.name] = value;
-			$.ajax($.extend(true, {
+			data[ element.name ] = value;
+			$.ajax( $.extend( true, {
 				url: param,
 				mode: "abort",
 				port: "validate" + element.name,
@@ -1206,25 +1242,25 @@ $.extend($.validator, {
 					var valid = response === true || response === "true",
 						errors, message, submitted;
 
-					validator.settings.messages[element.name].remote = previous.originalMessage;
+					validator.settings.messages[ element.name ].remote = previous.originalMessage;
 					if ( valid ) {
 						submitted = validator.formSubmitted;
-						validator.prepareElement(element);
+						validator.prepareElement( element );
 						validator.formSubmitted = submitted;
-						validator.successList.push(element);
-						delete validator.invalid[element.name];
+						validator.successList.push( element );
+						delete validator.invalid[ element.name ];
 						validator.showErrors();
 					} else {
 						errors = {};
 						message = response || validator.defaultMessage( element, "remote" );
-						errors[element.name] = previous.message = $.isFunction(message) ? message(value) : message;
-						validator.invalid[element.name] = true;
-						validator.showErrors(errors);
+						errors[ element.name ] = previous.message = $.isFunction( message ) ? message( value ) : message;
+						validator.invalid[ element.name ] = true;
+						validator.showErrors( errors );
 					}
 					previous.valid = valid;
-					validator.stopRequest(element, valid);
+					validator.stopRequest( element, valid );
 				}
-			}, param));
+			}, param ) );
 			return "pending";
 		}
 
@@ -1236,4 +1272,4 @@ $.format = function deprecated() {
 	throw "$.format has been deprecated. Please use $.validator.format instead.";
 };
 
-}(jQuery));
+}( jQuery ));

--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -1,0 +1,235 @@
+module( "placement" );
+
+test( "elements() order", function() {
+	var container = $( "#orderContainer" ),
+		v = $( "#elementsOrder" ).validate({
+			errorLabelContainer: container,
+			wrap: "li"
+		});
+
+	deepEqual( v.elements().map( function() {
+		return $( this ).attr( "id" );
+	}).get(), ["order1", "order2", "order3", "order4", "order5", "order6"], "elements must be in document order" );
+	v.form();
+	deepEqual( container.children().map( function() {
+		return $( this ).attr( "id" );
+	}).get(), ["order1-error", "order2-error", "order3-error", "order4-error", "order5-error", "order6-error"], "labels in error container must be in document order" );
+});
+
+test( "error containers, simple", function() {
+	expect( 14 );
+	var container = $( "#simplecontainer" ),
+		v = $( "#form" ).validate({
+			errorLabelContainer: container,
+			showErrors: function() {
+				container.find( "h3" ).html( jQuery.validator.format( "There are {0} errors in your form.", this.size()) );
+				this.defaultShowErrors();
+			}
+		});
+
+	v.prepareForm();
+	ok( v.valid(), "form is valid" );
+	equal( 0, container.find( ".error:not(input)" ).length, "There should be no error labels" );
+	equal( "", container.find( "h3" ).html() );
+
+	v.prepareForm();
+	v.errorList = [{message:"bar", element: {name:"foo"}}, {message: "necessary", element: {name:"required"}}];
+	ok( !v.valid(), "form is not valid after adding errors manually" );
+	v.showErrors();
+	equal( container.find( ".error:not(input)" ).length, 2, "There should be two error labels" );
+	ok( container.is( ":visible" ), "Check that the container is visible" );
+	container.find( ".error:not(input)" ).each(function() {
+		ok( $( this ).is( ":visible" ), "Check that each label is visible" );
+	});
+	equal( "There are 2 errors in your form.", container.find( "h3" ).html() );
+
+	v.prepareForm();
+	ok( v.valid(), "form is valid after a reset" );
+	v.showErrors();
+	equal( container.find( ".error:not(input)" ).length, 2, "There should still be two error labels" );
+	ok( container.is( ":hidden" ), "Check that the container is hidden" );
+	container.find( ".error:not(input)" ).each(function() {
+		ok( $( this ).is( ":hidden" ), "Check that each label is hidden" );
+	});
+});
+
+test( "error containers, with labelcontainer I", function() {
+	expect( 16 );
+	var container = $( "#container" ),
+		labelcontainer = $( "#labelcontainer" ),
+		v = $( "#form" ).validate({
+			errorContainer: container,
+			errorLabelContainer: labelcontainer,
+			wrapper: "li"
+		});
+
+	ok( v.valid(), "form is valid" );
+	equal( 0, container.find( ".error:not(input)" ).length, "There should be no error labels in the container" );
+	equal( 0, labelcontainer.find( ".error:not(input)" ).length, "There should be no error labels in the labelcontainer" );
+	equal( 0, labelcontainer.find( "li" ).length, "There should be no lis labels in the labelcontainer" );
+
+	v.errorList = [{message:"bar", element: {name:"foo"}}, {name: "required", message: "necessary", element: {name:"required"}}];
+	ok( !v.valid(), "form is not valid after adding errors manually" );
+	v.showErrors();
+	equal( 0, container.find( ".error:not(input)" ).length, "There should be no error label in the container" );
+	equal( 2, labelcontainer.find( ".error:not(input)" ).length, "There should be two error labels in the labelcontainer" );
+	equal( 2, labelcontainer.find( "li" ).length, "There should be two error lis in the labelcontainer" );
+	ok( container.is( ":visible" ), "Check that the container is visible" );
+	ok( labelcontainer.is( ":visible" ), "Check that the labelcontainer is visible" );
+	labelcontainer.find( ".error:not(input)" ).each(function() {
+		ok( $( this ).is( ":visible" ), "Check that each label is visible1" );
+		equal( "li", $( this ).parent()[0].tagName.toLowerCase(), "Check that each label is wrapped in an li" );
+		ok( $( this ).parent( "li" ).is( ":visible" ), "Check that each parent li is visible" );
+	});
+});
+
+test( "errorcontainer, show/hide only on submit", function() {
+	expect( 14 );
+	var container = $( "#container" ),
+		labelContainer = $( "#labelcontainer" ),
+		v = $( "#testForm1" ).bind( "invalid-form.validate", function() {
+			ok( true, "invalid-form event triggered called" );
+		}).validate({
+			errorContainer: container,
+			errorLabelContainer: labelContainer,
+			showErrors: function() {
+				container.html( jQuery.validator.format( "There are {0} errors in your form.", this.numberOfInvalids()) );
+				ok( true, "showErrors called" );
+				this.defaultShowErrors();
+			}
+		});
+
+	equal( "", container.html(), "must be empty" );
+	equal( "", labelContainer.html(), "must be empty" );
+	// validate whole form, both showErrors and invalidHandler must be called once
+	// preferably invalidHandler first, showErrors second
+	ok( !v.form(), "invalid form" );
+	equal( 2, labelContainer.find( ".error:not(input)" ).length );
+	equal( "There are 2 errors in your form.", container.html() );
+	ok( labelContainer.is( ":visible" ), "must be visible" );
+	ok( container.is( ":visible" ), "must be visible" );
+
+	$( "#firstname" ).val( "hix" ).keyup();
+	$( "#testForm1" ).triggerHandler( "keyup", [jQuery.event.fix({ type: "keyup", target: $( "#firstname" )[0] })]);
+	equal( 1, labelContainer.find( ".error:visible" ).length );
+	equal( "There are 1 errors in your form.", container.html() );
+
+	$( "#lastname" ).val( "abc" );
+	ok( v.form(), "Form now valid, trigger showErrors but not invalid-form" );
+});
+
+test( "test label used as error container", function(assert) {
+	expect( 8 );
+	var form = $( "#testForm16" ),
+		field = $( "#testForm16text" );
+		
+	form.validate({
+		errorPlacement: function( error, element ) {
+			// Append error within linked label
+			$( "label[for='" + element.attr( "id" ) + "']" ).append( error );
+		},
+		errorElement: "span"
+	});
+	
+	ok( !field.valid() );
+	equal( "Field Label", field.next( "label" ).contents( ":not(span)" ).text(), "container label isn't disrupted" );
+	assert.hasError(field, "missing");
+	ok( !field.attr( "aria-describedby" ), "field does not require aria-describedby attribute" );
+
+	field.val( "foo" );
+	ok( field.valid() );
+	equal( "Field Label", field.next( "label" ).contents( ":not(span)" ).text(), "container label isn't disrupted" );
+	ok( !field.attr( "aria-describedby" ), "field does not require aria-describedby attribute" );
+	assert.noErrorFor(field);
+});
+
+test( "test error placed adjacent to descriptive label", function(assert) {
+	expect( 8 );
+	var form = $( "#testForm16" ),
+		field = $( "#testForm16text" );
+		
+	form.validate({
+		errorElement: "span"
+	});
+		
+	ok( !field.valid() );
+	equal( 1, form.find( "label" ).length );
+	equal( "Field Label", form.find( "label" ).text(), "container label isn't disrupted" );
+	assert.hasError( field, "missing" );
+
+	field.val( "foo" );
+	ok( field.valid() );
+	equal( 1, form.find( "label" ).length );
+	equal( "Field Label", form.find( "label" ).text(), "container label isn't disrupted" );
+	assert.noErrorFor( field );
+});
+
+test( "test descriptive label used alongside error label", function(assert) {
+	expect( 8 );
+	var form = $( "#testForm16" ),
+		field = $( "#testForm16text" );
+		
+	form.validate({
+		errorElement: "label"
+	});
+		
+	ok( !field.valid() );
+	equal( 1, form.find( "label.title" ).length );
+	equal( "Field Label", form.find( "label.title" ).text(), "container label isn't disrupted" );
+	assert.hasError( field, "missing" );
+
+	field.val( "foo" );
+	ok( field.valid() );
+	equal( 1, form.find( "label.title" ).length );
+	equal( "Field Label", form.find( "label.title" ).text(), "container label isn't disrupted" );
+	assert.noErrorFor( field );
+});
+
+test( "test custom errorElement", function(assert) {
+	expect( 4 );
+	var form = $( "#userForm" ),
+		field = $( "#username" );
+		
+	form.validate({
+		messages: {
+			username: "missing"
+		},
+		errorElement: "label"
+	});
+		
+	ok( !field.valid() );
+	assert.hasError( field, "missing", "Field should have error 'missing'" );
+	field.val( "foo" );
+	ok( field.valid() );
+	assert.noErrorFor( field, "Field should not have a visible error" );
+});
+
+test( "test existing label used as error element", function(assert) {
+	expect( 4 );
+	var form = $( "#testForm14" ),
+		field = $( "#testForm14text" );
+		
+	form.validate({errorElement: "label"});
+		
+	ok( !field.valid() );
+	assert.hasError( field, "required" );
+
+	field.val( "foo" );
+	ok( field.valid() );
+	assert.noErrorFor( field );
+});
+
+test( "test existing non-label used as error element", function(assert) {
+	expect( 4 );
+	var form = $( "#testForm15" ),
+		field = $( "#testForm15text" );
+		
+	form.validate({errorElement: "span"});
+		
+	ok( !field.valid() );
+	assert.hasError( field );
+
+	field.val( "foo" );
+	ok( field.valid() );
+	assert.noErrorFor( field );
+});

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
 	<script src="messages.js"></script>
 	<script src="methods.js"></script>
 	<script src="aria.js"></script>
+	<script src="error-placement.js"></script>
 </head>
 <body id="body">
 <h1 id="qunit-header">
@@ -65,8 +66,8 @@
 		<input type="text" data-rule-required="true" title="something" name="something" id="something" value="something" />
 	</form>
 	<form id="testForm1clean">
-		<input title="buga" name="firstname" id="firstnamec" />
-		<label id="errorFirstname" for="firstname" class="error">error for firstname</label>
+		<input title="buga" name="firstnamec" id="firstnamec" />
+		<label id="errorFirstnamec" for="firstnamec" class="error">error for firstname</label>
 		<input title="buga" name="lastname" id="lastnamec" />
 		<input name="username" id="usernamec" />
 	</form>
@@ -148,6 +149,21 @@
 			<option value="vw_p">VW Polo</option>
 			<option value="t_s">Titanic Skoda</option>
 		</select>
+	</form>
+	<form id="testForm14">
+		<!-- test existing "label" error holder -->
+		<input name="testForm14text" id="testForm14text" data-rule-required="true" data-msg="required" />
+		<label for="testForm14text" class="error"></label>
+	</form>
+	<form id="testForm16">
+		<!-- test existing "label" attribute -->
+		<input name="testForm16text" id="testForm16text" data-rule-required="true" data-msg="missing" />
+		<label for="testForm16text" class="title">Field Label</label>
+	</form>
+	<form id="testForm15">
+		<!-- test existing non-label error holder -->
+		<input name="testForm15text" id="testForm15text" data-rule-required="true" data-msg="required" aria-describedby="testForm15text-error" />
+		<span id="testForm15text-error" class="error"></span>
 	</form>
 	<form id="dataMessages">
 		<input name="dataMessagesName" id="dataMessagesName" class="required" data-msg-required="You must enter a value here" />

--- a/test/messages.js
+++ b/test/messages.js
@@ -27,16 +27,16 @@ test("group error messages", function() {
 	});
 	ok( !form.valid() );
 	equal( 1, form.find(".errorContainer *").length );
-	equal( "Please enter a valid date.", form.find(".errorContainer label.error").text() );
+	equal( "Please enter a valid date.", form.find(".errorContainer .error:not(input)").text() );
 
 	$("#fromDate").val("12/03/2006");
 	$("#toDate").val("12/01/2006");
 	ok( !form.valid() );
-	equal( "Please specify a correct date range.", form.find(".errorContainer label.error").text() );
+	equal( "Please specify a correct date range.", form.find(".errorContainer .error:not(input)").text() );
 
 	$("#toDate").val("12/04/2006");
 	ok( form.valid() );
-	ok( form.find(".errorContainer label.error").is(":hidden") );
+	ok( form.find(".errorContainer .error:not(input)").is(":hidden") );
 });
 
 test("read messages from metadata", function() {
@@ -46,15 +46,15 @@ test("read messages from metadata", function() {
 	form.validate();
 	e = $("#testEmail9");
 	e.valid();
-	equal( form.find("label[for=testEmail9]").text(), "required" );
+	equal( form.find("#testEmail9").next(".error:not(input)").text(), "required" );
 	e.val("bla").valid();
-	equal( form.find("label[for=testEmail9]").text(), "email" );
+	equal( form.find("#testEmail9").next(".error:not(input)").text(), "email" );
 
 	g = $("#testGeneric9");
 	g.valid();
-	equal( form.find("label[for=testGeneric9]").text(), "generic");
+	equal( form.find("#testGeneric9").next(".error:not(input)").text(), "generic");
 	g.val("bla").valid();
-	equal( form.find("label[for=testGeneric9]").text(), "email" );
+	equal( form.find("#testGeneric9").next(".error:not(input)").text(), "email" );
 });
 
 
@@ -63,7 +63,7 @@ test("read messages from metadata, with meta option specified, but no metadata i
 	form.validate({
 		meta: "validate",
 		rules: {
-			firstname: "required"
+			firstnamec: "required"
 		}
 	});
 	ok(!form.valid(), "not valid");

--- a/test/rules.js
+++ b/test/rules.js
@@ -13,7 +13,7 @@ test("rules(), ignore method:false", function() {
 
 	$("#testForm1clean").validate({
 		rules: {
-			firstname: { required: false, minlength: 2 }
+			firstnamec: { required: false, minlength: 2 }
 		}
 	});
 
@@ -83,7 +83,7 @@ test("rules(), merge min/max to range, minlength/maxlength to rangelength", func
 
 	$("#testForm1clean").validate({
 		rules: {
-			firstname: {
+			firstnamec: {
 				min: 5,
 				max: 12
 			},
@@ -133,7 +133,7 @@ test("rules(), evaluate dynamic parameters", function() {
 
 	$("#testForm1clean").validate({
 		rules: {
-			firstname: {
+			firstnamec: {
 				min: function(element) {
 					equal( $("#firstnamec")[0], element );
 					return 12;
@@ -184,7 +184,7 @@ test("rules(), class and attribute combinations", function() {
 test("rules(), dependency checks", function() {
 	var v = $("#testForm1clean").validate({
 			rules: {
-				firstname: {
+				firstnamec: {
 					min: {
 						param: 5,
 						depends: function(el) {
@@ -237,7 +237,7 @@ test("rules(), add and remove static rules", function() {
 
 	$("#testForm1clean").validate({
 		rules: {
-			firstname: "required date"
+			firstnamec: "required date"
 		}
 	});
 
@@ -276,7 +276,7 @@ test("rules(), add messages", function() {
 	$("#firstnamec").attr("title", null);
 	var v = $("#testForm1clean").validate({
 		rules: {
-			firstname: "required"
+			firstnamec: "required"
 		}
 	});
 	$("#testForm1clean").valid();

--- a/test/test.js
+++ b/test/test.js
@@ -26,264 +26,278 @@ $.mockjax({
 });
 $.mockjax({
 	url: "echo.php",
-	response: function(data) {
-		this.responseText = JSON.stringify(data.data);
+	response: function( data ) {
+		this.responseText = JSON.stringify( data.data );
 	},
 	responseTime: 100
 });
 
-module("validator");
+// Asserts that there is a visible error with the given text for the specified element
+QUnit.assert.hasError = function( element, text, message ) {
+	var errors = $( element ).closest( "form" ).validate().errorsFor( element[ 0 ] ),
+		actual = ( errors.length === 1 && errors.is( ":visible" ) ) ? errors.text() : "";
+	QUnit.push( actual, actual, text, message );
+};
 
-test("Constructor", function() {
-	var v1 = $("#testForm1").validate(),
-		v2 = $("#testForm1").validate();
+// Asserts that there is no visible error for the given element
+QUnit.assert.noErrorFor = function( element, message ) {
+	var errors = $( element ).closest( "form" ).validate().errorsFor( element[ 0 ] ),
+		hidden = ( errors.length === 0 ) || errors.is( ":hidden" ) || ( errors.text() === "" );
+	QUnit.push( hidden, hidden, true, message );
+};
+
+module( "validator" );
+
+test( "Constructor", function() {
+	var v1 = $( "#testForm1" ).validate(),
+		v2 = $( "#testForm1" ).validate();
 
 	equal( v1, v2, "Calling validate() multiple times must return the same validator instance" );
 	equal( v1.elements().length, 3, "validator elements" );
 });
 
-test("validate() without elements, with non-form elements", 0, function() {
-	$("#doesntexist").validate();
+test( "validate() without elements, with non-form elements", 0, function() {
+	$( "#doesntexist" ).validate();
 });
 
-test("valid() plugin method", function() {
-	var form = $("#userForm"),
-		input = $("#username");
+test( "valid() plugin method", function() {
+	var form = $( "#userForm" ),
+		input = $( "#username" );
 
 	form.validate();
 	ok ( !form.valid(), "Form isn't valid yet" );
 	ok ( !input.valid(), "Input isn't valid either" );
 
-	input.val("Hello world");
+	input.val( "Hello world" );
 	ok ( form.valid(), "Form is now valid" );
 	ok ( input.valid(), "Input is valid, too" );
 });
 
-test("valid() plugin method, multiple inputs", function() {
-	var form = $("#testForm1"),
+test( "valid() plugin method, multiple inputs", function() {
+	var form = $( "#testForm1" ),
 		validator = form.validate(),
-		inputs = form.find("input");
+		inputs = form.find( "input" );
 
 	ok( !inputs.valid(), "all invalid" );
-	inputs.not(":first").val("ok");
+	inputs.not( ":first" ).val( "ok" );
 	equal( validator.numberOfInvalids(), 2 );
 	strictEqual( inputs.valid(), false, "just one invalid" );
-	inputs.val("ok");
+	inputs.val( "ok" );
 	strictEqual( inputs.valid(), true, "all valid" );
 });
 
-test("valid() plugin method, special handling for checkable groups", function() {
+test( "valid() plugin method, special handling for checkable groups", function() {
 	// rule is defined on first checkbox, must apply to others, too
-	var checkable = $("#checkable2");
+	var checkable = $( "#checkable2" );
 	ok( !checkable.valid(), "must be invalid, not checked yet" );
-	checkable.attr("checked", true);
+	checkable.attr( "checked", true );
 	ok( checkable.valid(), "valid, is now checked" );
-	checkable.attr("checked", false);
+	checkable.attr( "checked", false );
 	ok( !checkable.valid(), "invalid again" );
-	$("#checkable3").attr("checked", true);
+	$( "#checkable3" ).attr( "checked", true );
 	ok( checkable.valid(), "valid, third box is checked" );
 });
 
-test("addMethod", function() {
+test( "addMethod", function() {
 	expect( 3 );
-	$.validator.addMethod("hi", function(value) {
+	$.validator.addMethod( "hi", function( value ) {
 		return value === "hi";
-	}, "hi me too");
+	}, "hi me too" );
 	var method = $.validator.methods.hi,
-		e = $("#text1")[0];
-	ok( !method(e.value, e), "Invalid" );
+		e = $( "#text1" )[ 0 ];
+	ok( !method( e.value, e ), "Invalid" );
 	e.value = "hi";
-	ok( method(e.value, e), "Invalid" );
+	ok( method( e.value, e ), "Invalid" );
 	ok( jQuery.validator.messages.hi === "hi me too", "Check custom message" );
 });
 
-test("addMethod2", function() {
+test( "addMethod2", function() {
 	expect( 4 );
-	$.validator.addMethod("complicatedPassword", function(value, element) {
-		return this.optional(element) || /\D/.test(value) && /\d/.test(value);
-	}, "Your password must contain at least one number and one letter");
-	var v = jQuery("#form").validate({
+	$.validator.addMethod( "complicatedPassword", function( value, element ) {
+		return this.optional( element ) || /\D/.test( value ) && /\d/.test( value );
+	}, "Your password must contain at least one number and one letter" );
+	var v = jQuery( "#form" ).validate({
 			rules: {
 				action: { complicatedPassword: true }
 			}
 		}),
-		e = $("#text1")[0];
+		e = $( "#text1" )[ 0 ];
 
 	e.value = "";
-	strictEqual( v.element(e), true, "Rule is optional, valid" );
+	strictEqual( v.element( e ), true, "Rule is optional, valid" );
 	equal( 0, v.size() );
 	e.value = "ko";
-	ok( !v.element(e), "Invalid, doesn't contain one of the required characters" );
+	ok( !v.element( e ), "Invalid, doesn't contain one of the required characters" );
 	e.value = "ko1";
-	ok( v.element(e) );
+	ok( v.element( e ) );
 });
 
-test("form(): simple", function() {
+test( "form(): simple", function() {
 	expect( 2 );
-	var form = $("#testForm1")[0],
-		v = $(form).validate();
+	var form = $( "#testForm1" )[ 0 ],
+		v = $( form ).validate();
 
 	ok( !v.form(), "Invalid form" );
-	$("#firstname").val("hi");
-	$("#lastname").val("hi");
+	$( "#firstname" ).val( "hi" );
+	$( "#lastname" ).val( "hi" );
 	ok( v.form(), "Valid form" );
 });
 
-test("form(): checkboxes: min/required", function() {
+test( "form(): checkboxes: min/required", function() {
 	expect( 3 );
-	var form = $("#testForm6")[0],
-		v = $(form).validate();
+	var form = $( "#testForm6" )[ 0 ],
+		v = $( form ).validate();
 
 	ok( !v.form(), "Invalid form" );
-	$("#form6check1").attr("checked", true);
+	$( "#form6check1" ).attr( "checked", true );
 	ok( !v.form(), "Invalid form" );
-	$("#form6check2").attr("checked", true);
+	$( "#form6check2" ).attr( "checked", true );
 	ok( v.form(), "Valid form" );
 });
 
-test("form(): radio buttons: required", function () {
+test( "form(): radio buttons: required", function () {
 	expect( 6 );
-	var form = $("#testForm10")[0],
-		v = $(form).validate({ rules: { testForm10Radio: "required"} });
+	var form = $( "#testForm10" )[ 0 ],
+		v = $( form ).validate({ rules: { testForm10Radio: "required"} });
 
-	ok(!v.form(), "Invalid Form");
-	equal($("#testForm10Radio1").attr("class"), "error");
-	equal($("#testForm10Radio2").attr("class"), "error");
+	ok(!v.form(), "Invalid Form" );
+	equal($( "#testForm10Radio1" ).attr( "class" ), "error" );
+	equal($( "#testForm10Radio2" ).attr( "class" ), "error" );
 
-	$("#testForm10Radio2").attr("checked", true);
-	ok(v.form(), "Valid form");
+	$( "#testForm10Radio2" ).attr( "checked", true );
+	ok( v.form(), "Valid form" );
 
-	equal($("#testForm10Radio1").attr("class"), "valid");
-	equal($("#testForm10Radio2").attr("class"), "valid");
+	equal($( "#testForm10Radio1" ).attr( "class" ), "valid" );
+	equal($( "#testForm10Radio2" ).attr( "class" ), "valid" );
 });
 
-test("form(): selects: min/required", function() {
+test( "form(): selects: min/required", function() {
 	expect( 3 );
-	var form = $("#testForm7")[0],
-		v = $(form).validate();
+	var form = $( "#testForm7" )[ 0 ],
+		v = $( form ).validate();
 
 	ok( !v.form(), "Invalid form" );
-	$("#optionxa").attr("selected", true);
+	$( "#optionxa" ).attr( "selected", true );
 	ok( !v.form(), "Invalid form" );
-	$("#optionxb").attr("selected", true);
+	$( "#optionxb" ).attr( "selected", true );
 	ok( v.form(), "Valid form" );
 });
 
-test("form(): with equalTo", function() {
+test( "form(): with equalTo", function() {
 	expect( 2 );
-	var form = $("#testForm5")[0],
-		v = $(form).validate();
+	var form = $( "#testForm5" )[ 0 ],
+		v = $( form ).validate();
 
 	ok( !v.form(), "Invalid form" );
-	$("#x1, #x2").val("hi");
+	$( "#x1, #x2" ).val( "hi" );
 	ok( v.form(), "Valid form" );
 });
 
-test("form(): with equalTo and onfocusout=false", function() {
+test( "form(): with equalTo and onfocusout=false", function() {
 	expect( 4 );
-	var form = $("#testForm5")[0],
-		v = $(form).validate({
+	var form = $( "#testForm5" )[ 0 ],
+		v = $( form ).validate({
 			onfocusout: false,
 			showErrors: function() {
-				ok(true, "showErrors should only be called twice");
+				ok( true, "showErrors should only be called twice" );
 				this.defaultShowErrors();
 			}
 		});
 
-	$("#x1, #x2").val("hi");
+	$( "#x1, #x2" ).val( "hi" );
 	ok( v.form(), "Valid form" );
-	$("#x2").val("not equal").blur();
+	$( "#x2" ).val( "not equal" ).blur();
 	ok( !v.form(), "Invalid form" );
 });
 
 
-test("check(): simple", function() {
+test( "check(): simple", function() {
 	expect( 3 );
-	var element = $("#firstname")[0],
-		v = $("#testForm1").validate();
+	var element = $( "#firstname" )[ 0 ],
+		v = $( "#testForm1" ).validate();
 
 	ok( v.size() === 0, "No errors yet" );
-	v.check(element);
+	v.check( element );
 	ok( v.size() === 1, "error exists" );
 	v.errorList = [];
-	$("#firstname").val("hi");
-	v.check(element);
+	$( "#firstname" ).val( "hi" );
+	v.check( element );
 	ok( v.size() === 0, "No more errors" );
 });
 
-test("hide(): input", function() {
+test( "hide(): input", function() {
 	expect( 3 );
-	var errorLabel = $("#errorFirstname"),
-		element = $("#firstname")[0],
+	var errorLabel = $( "#errorFirstname" ),
+		element = $( "#firstname" )[ 0 ],
 		v;
 
 	element.value ="bla";
-	v = $("#testForm1").validate();
+	v = $( "#testForm1" ).validate();
 	errorLabel.show();
 
-	ok( errorLabel.is(":visible"), "Error label visible before validation" );
-	ok( v.element(element) );
-	ok( errorLabel.is(":hidden"), "Error label not visible after validation" );
+	ok( errorLabel.is( ":visible" ), "Error label visible before validation" );
+	ok( v.element( element ) );
+	ok( errorLabel.is( ":hidden" ), "Error label not visible after validation" );
 });
 
-test("hide(): radio", function() {
+test( "hide(): radio", function() {
 	expect( 2 );
-	var errorLabel = $("#agreeLabel"),
-		element = $("#agb")[0],
+	var errorLabel = $( "#agreeLabel" ),
+		element = $( "#agb" )[ 0 ],
 		v;
 
 	element.checked = true;
-	v = $("#testForm2").validate({ errorClass: "xerror" });
+	v = $( "#testForm2" ).validate({ errorClass: "xerror" });
 	errorLabel.show();
 
-	ok( errorLabel.is(":visible"), "Error label visible after validation" );
-	v.element(element);
-	ok( errorLabel.is(":hidden"), "Error label not visible after hiding it" );
+	ok( errorLabel.is( ":visible" ), "Error label visible after validation" );
+	v.element( element );
+	ok( errorLabel.is( ":hidden" ), "Error label not visible after hiding it" );
 });
 
-test("hide(): errorWrapper", function() {
-	expect(2);
-	var errorLabel = $("#errorWrapper"),
-		element = $("#meal")[0],
+test( "hide(): errorWrapper", function() {
+	expect( 2 );
+	var errorLabel = $( "#errorWrapper" ),
+		element = $( "#meal" )[ 0 ],
 		v;
 
 	element.selectedIndex = 1;
 	errorLabel.show();
 
-	ok( errorLabel.is(":visible"), "Error label visible after validation" );
-	v = $("#testForm3").validate({ wrapper: "li", errorLabelContainer: $("#errorContainer") });
-	v.element(element);
-	ok( errorLabel.is(":hidden"), "Error label not visible after hiding it" );
+	ok( errorLabel.is( ":visible" ), "Error label visible after validation" );
+	v = $( "#testForm3" ).validate({ wrapper: "li", errorLabelContainer: $( "#errorContainer" ) });
+	v.element( element );
+	ok( errorLabel.is( ":hidden" ), "Error label not visible after hiding it" );
 });
 
-test("hide(): container", function() {
-	expect(4);
-	var errorLabel = $("#errorContainer"),
-		v = $("#testForm3").validate({ errorWrapper: "li", errorContainer: $("#errorContainer") });
+test( "hide(): container", function() {
+	expect( 4 );
+	var errorLabel = $( "#errorContainer" ),
+		v = $( "#testForm3" ).validate({ errorWrapper: "li", errorContainer: $( "#errorContainer" ) });
 
 	v.form();
-	ok( errorLabel.is(":visible"), "Error label visible after validation" );
-	$("#meal")[0].selectedIndex = 1;
+	ok( errorLabel.is( ":visible" ), "Error label visible after validation" );
+	$( "#meal" )[ 0 ].selectedIndex = 1;
 	v.form();
-	ok( errorLabel.is(":hidden"), "Error label not visible after hiding it" );
-	$("#meal")[0].selectedIndex = -1;
-	v.element("#meal");
-	ok( errorLabel.is(":visible"), "Error label visible after validation" );
-	$("#meal")[0].selectedIndex = 1;
-	v.element("#meal");
-	ok( errorLabel.is(":hidden"), "Error label not visible after hiding it" );
+	ok( errorLabel.is( ":hidden" ), "Error label not visible after hiding it" );
+	$( "#meal" )[ 0 ].selectedIndex = -1;
+	v.element( "#meal" );
+	ok( errorLabel.is( ":visible" ), "Error label visible after validation" );
+	$( "#meal" )[ 0 ].selectedIndex = 1;
+	v.element( "#meal" );
+	ok( errorLabel.is( ":hidden" ), "Error label not visible after hiding it" );
 });
 
-test("valid()", function() {
-	expect(4);
-	var errorList = [{name:"meal",message:"foo", element:$("#meal")[0]}],
-		v = $("#testForm3").validate();
+test( "valid()", function() {
+	expect( 4 );
+	var errorList = [{ name:"meal", message:"foo", element:$( "#meal" )[ 0 ] }],
+		v = $( "#testForm3" ).validate();
 
 	ok( v.valid(), "No errors, must be valid" );
 	v.errorList = errorList;
 	ok( !v.valid(), "One error, must be invalid" );
 	QUnit.reset();
-	v = $("#testForm3").validate({ submitHandler: function() {
+	v = $( "#testForm3" ).validate({ submitHandler: function() {
 		ok( false, "Submit handler was called" );
 	}});
 	ok( v.valid(), "No errors, must be valid and returning true, even with the submit handler" );
@@ -291,24 +305,24 @@ test("valid()", function() {
 	ok( !v.valid(), "One error, must be invalid, no call to submit handler" );
 });
 
-test("submitHandler keeps submitting button", function() {
+test( "submitHandler keeps submitting button", function() {
 	var button, event;
 
-	$("#userForm").validate({
+	$( "#userForm" ).validate({
 		debug: true,
-		submitHandler: function(form) {
+		submitHandler: function( form ) {
 			// dunno how to test this better; this tests the implementation that uses a hidden input
-			var hidden = $(form).find("input:hidden")[0];
-			deepEqual(hidden.value, button.value);
-			deepEqual(hidden.name, button.name);
+			var hidden = $( form ).find( "input:hidden" )[ 0 ];
+			deepEqual( hidden.value, button.value );
+			deepEqual( hidden.name, button.name );
 		}
 	});
-	$("#username").val("bla");
-	button = $("#userForm :submit")[0];
-	event = $.Event("click");
+	$( "#username" ).val( "bla" );
+	button = $( "#userForm :submit" )[ 0 ];
+	event = $.Event( "click" );
 	event.preventDefault();
-	$.event.trigger(event, null, button);
-	$("#userForm").submit();
+	$.event.trigger( event, null, button );
+	$( "#userForm" ).submit();
 });
 
 asyncTest("validation triggered on radio/checkbox when using keyboard", function() {
@@ -350,20 +364,20 @@ asyncTest("validation triggered on radio/checkbox when using keyboard", function
 	}, 50);
 });
 
-test("showErrors()", function() {
+test( "showErrors()", function() {
 	expect( 4 );
-	var errorLabel = $("#errorFirstname").hide(),
-		v = $("#testForm1").validate();
+	var errorLabel = $( "#errorFirstname" ).hide(),
+		v = $( "#testForm1" ).validate();
 
-	ok( errorLabel.is(":hidden") );
-	equal( 0, $("label.error[for=lastname]").size() );
+	ok( errorLabel.is( ":hidden" ) );
+	equal( 0, $( "#lastname" ).next( ".error:not(input)" ).size() );
 	v.showErrors({"firstname": "required", "lastname": "bla"});
-	equal( true, errorLabel.is(":visible") );
-	equal( true, $("label.error[for=lastname]").is(":visible") );
+	equal( true, errorLabel.is( ":visible" ) );
+	equal( true, $( "#lastname" ).next( ".error:not(input)" ).is( ":visible" ) );
 });
 
-test("showErrors(), allow empty string and null as default message", function() {
-	$("#userForm").validate({
+test( "showErrors(), allow empty string and null as default message", function() {
+	$( "#userForm" ).validate({
 		rules: {
 			username: {
 				required: true,
@@ -377,48 +391,48 @@ test("showErrors(), allow empty string and null as default message", function() 
 			}
 		}
 	});
-	ok( !$("#username").valid() );
-	equal( "", $("label.error[for=username]").text() );
+	ok( !$( "#username" ).valid() );
+	equal( "", $( "#username" ).next( ".error:not(input)" ).text() );
 
-	$("#username").val("ab");
-	ok( !$("#username").valid() );
-	equal( "too short", $("label.error[for=username]").text() );
+	$( "#username" ).val( "ab" );
+	ok( !$( "#username" ).valid() );
+	equal( "too short", $( "#username" ).next( ".error:not(input)" ).text() );
 
-	$("#username").val("abc");
-	ok( $("#username").valid() );
-	ok( $("label.error[for=username]").is(":hidden") );
+	$( "#username" ).val( "abc" );
+	ok( $( "#username" ).valid() );
+	ok( $( "#username" ).next( ".error:not(input)" ).is( ":hidden" ) );
 });
 
-test("showErrors() - external messages", function() {
+test( "showErrors() - external messages", function() {
 	expect( 4 );
-	var methods = $.extend({}, $.validator.methods),
-		messages = $.extend({}, $.validator.messages),
+	var methods = $.extend( {}, $.validator.methods ),
+		messages = $.extend( {}, $.validator.messages ),
 		form, v;
 
-	$.validator.addMethod("foo", function() { return false; });
-	$.validator.addMethod("bar", function() { return false; });
-	equal( 0, $("#testForm4 label.error[for=f1]").size() );
-	equal( 0, $("#testForm4 label.error[for=f2]").size() );
+	$.validator.addMethod( "foo", function() { return false; });
+	$.validator.addMethod( "bar", function() { return false; });
+	equal( 0, $( "#testForm4 #f1" ).next( ".error:not(input)" ).size() );
+	equal( 0, $( "#testForm4 #f2" ).next( ".error:not(input)" ).size() );
 
-	form = $("#testForm4")[0];
-	v = $(form).validate({
+	form = $( "#testForm4" )[ 0 ];
+	v = $( form ).validate({
 		messages: {
 			f1: "Please!",
 			f2: "Wohoo!"
 		}
 	});
 	v.form();
-	equal( $("#testForm4 label.error[for=f1]").text(), "Please!" );
-	equal( $("#testForm4 label.error[for=f2]").text(), "Wohoo!" );
+	equal( $( "#testForm4 #f1" ).next( ".error:not(input)" ).text(), "Please!" );
+	equal( $( "#testForm4 #f2" ).next( ".error:not(input)" ).text(), "Wohoo!" );
 
 	$.validator.methods = methods;
 	$.validator.messages = messages;
 });
 
-test("showErrors() - custom handler", function() {
-	expect(5);
-	var v = $("#testForm1").validate({
-		showErrors: function(errorMap, errorList) {
+test( "showErrors() - custom handler", function() {
+	expect( 5 );
+	var v = $( "#testForm1" ).validate({
+		showErrors: function( errorMap, errorList ) {
 			equal( v, this );
 			equal( v.errorList, errorList );
 			equal( v.errorMap, errorMap );
@@ -429,457 +443,344 @@ test("showErrors() - custom handler", function() {
 	v.form();
 });
 
-test("option: (un)highlight, default", function() {
-	$("#testForm1").validate();
-	var e = $("#firstname");
-	ok( !e.hasClass("error") );
-	ok( !e.hasClass("valid") );
+test( "option: (un)highlight, default", function() {
+	$( "#testForm1" ).validate();
+	var e = $( "#firstname" );
+	ok( !e.hasClass( "error" ) );
+	ok( !e.hasClass( "valid" ) );
 	e.valid();
-	ok( e.hasClass("error") );
-	ok( !e.hasClass("valid") );
-	e.val("hithere").valid();
-	ok( !e.hasClass("error") );
-	ok( e.hasClass("valid") );
+	ok( e.hasClass( "error" ) );
+	ok( !e.hasClass( "valid" ) );
+	e.val( "hithere" ).valid();
+	ok( !e.hasClass( "error" ) );
+	ok( e.hasClass( "valid" ) );
 });
 
-test("option: (un)highlight, nothing", function() {
-	expect(3);
-	$("#testForm1").validate({
+test( "option: (un)highlight, nothing", function() {
+	expect( 3 );
+	$( "#testForm1" ).validate({
 		highlight: false,
 		unhighlight: false
 	});
-	var e = $("#firstname");
-	ok( !e.hasClass("error") );
+	var e = $( "#firstname" );
+	ok( !e.hasClass( "error" ) );
 	e.valid();
-	ok( !e.hasClass("error") );
+	ok( !e.hasClass( "error" ) );
 	e.valid();
-	ok( !e.hasClass("error") );
+	ok( !e.hasClass( "error" ) );
 });
 
-test("option: (un)highlight, custom", function() {
-	expect(5);
-	$("#testForm1clean").validate({
-		highlight: function(element, errorClass) {
+test( "option: (un)highlight, custom", function() {
+	expect( 5 );
+	$( "#testForm1clean" ).validate({
+		highlight: function( element, errorClass ) {
 			equal( "invalid", errorClass );
-			$(element).hide();
+			$( element ).hide();
 		},
-		unhighlight: function(element, errorClass) {
+		unhighlight: function( element, errorClass ) {
 			equal( "invalid", errorClass );
-			$(element).show();
+			$( element ).show();
 		},
 		errorClass: "invalid",
 		rules: {
-			firstname: "required"
+			firstnamec: "required"
 		}
 	});
-	var e = $("#firstnamec");
-	ok( e.is(":visible") );
+	var e = $( "#firstnamec" );
+	ok( e.is( ":visible" ) );
 	e.valid();
-	ok( !e.is(":visible") );
-	e.val("hithere").valid();
-	ok( e.is(":visible") );
+	ok( !e.is( ":visible" ) );
+	e.val( "hithere" ).valid();
+	ok( e.is( ":visible" ) );
 });
 
-test("option: (un)highlight, custom2", function() {
-	expect(6);
+test( "option: (un)highlight, custom2", function() {
+	expect( 6 );
 	var e, l;
-	$("#testForm1").validate({
-		highlight: function(element, errorClass) {
-			$(element).addClass(errorClass);
-			$(element.form).find("label[for=" + element.id + "]").addClass(errorClass);
+	$( "#testForm1" ).validate({
+		highlight: function( element, errorClass ) {
+			$( element ).addClass( errorClass );
+			$( element ).next( ".error:not(input)" ).addClass( errorClass );
 		},
-		unhighlight: function(element, errorClass) {
-			$(element).removeClass(errorClass);
-			$(element.form).find("label[for=" + element.id + "]").removeClass(errorClass);
+		unhighlight: function( element, errorClass ) {
+			$( element ).removeClass( errorClass );
+			$( element ).next( ".error:not(input)" ).removeClass( errorClass );
 		},
 		errorClass: "invalid"
 	});
 
-	e = $("#firstname");
-	l = $("#errorFirstname");
+	e = $( "#firstname" );
+	l = $( "#errorFirstname" );
 
-	ok( !e.is(".invalid") );
-	ok( !l.is(".invalid") );
+	ok( !e.is( ".invalid" ) );
+	ok( !l.is( ".invalid" ) );
 	e.valid();
-	ok( e.is(".invalid") );
-	ok( l.is(".invalid") );
-	e.val("hithere").valid();
-	ok( !e.is(".invalid") );
-	ok( !l.is(".invalid") );
+	ok( e.is( ".invalid" ) );
+	ok( l.is( ".invalid" ) );
+	e.val( "hithere" ).valid();
+	ok( !e.is( ".invalid" ) );
+	ok( !l.is( ".invalid" ) );
 });
 
-test("option: focusCleanup default false", function() {
-	var form = $("#userForm");
+test( "option: focusCleanup default false", function() {
+	var form = $( "#userForm" );
 	form.validate();
 	form.valid();
-	ok( form.is(":has(label.error[for=username]:visible)"));
-	$("#username").focus();
-	ok( form.is(":has(label.error[for=username]:visible)"));
+	ok( form.find( "#username" ).next( ".error:not(input)" ).is( ":visible" ));
+	$( "#username" ).focus();
+	ok( form.find( "#username" ).next( ".error:not(input)" ).is( ":visible" ));
 });
 
-test("option: focusCleanup true", function() {
-	var form = $("#userForm");
+test( "option: focusCleanup true", function() {
+	var form = $( "#userForm" );
 	form.validate({
 		focusCleanup: true
 	});
 	form.valid();
-	ok( form.is(":has(label.error[for=username]:visible)") );
-	$("#username").focus().trigger("focusin");
-	ok( !form.is(":has(label.error[for=username]:visible)") );
+	ok( form.find( "#username" ).next( ".error:not(input)" ).is( ":visible" ) );
+	$( "#username" ).focus().trigger( "focusin" );
+	ok( !form.find( "#username" ).next( ".error:not(input)" ).is( ":visible" ) );
 });
 
-test("option: focusCleanup with wrapper", function() {
-	var form = $("#userForm");
+test( "option: focusCleanup with wrapper", function() {
+	var form = $( "#userForm" );
 	form.validate({
 		focusCleanup: true,
 		wrapper: "span"
 	});
 	form.valid();
-	ok( form.is(":has(span:visible:has(label.error[for=username]))") );
-	$("#username").focus().trigger("focusin");
-	ok( !form.is(":has(span:visible:has(label.error[for=username]))") );
+	ok( form.is( ":has(span:visible:has(.error#username-error))" ) );
+	$( "#username" ).focus().trigger( "focusin" );
+	ok( !form.is( ":has(span:visible:has(.error#username-error))" ) );
 });
 
-test("option: errorClass with multiple classes", function() {
-	var form = $("#userForm");
+test( "option: errorClass with multiple classes", function() {
+	var form = $( "#userForm" );
 	form.validate({
 		focusCleanup: true,
 		wrapper: "span",
 		errorClass: "error error1 error2"
 	});
 	form.valid();
-	ok( form.is(":has(span:visible:has(label.error[for=username]))") );
-	ok( form.is(":has(span:visible:has(label.error1[for=username]))") );
-	ok( form.is(":has(span:visible:has(label.error2[for=username]))") );
-	$("#username").focus().trigger("focusin");
-	ok( !form.is(":has(span:visible:has(label.error[for=username]))") );
-	ok( !form.is(":has(span:visible:has(label.error1[for=username]))") );
-	ok( !form.is(":has(span:visible:has(label.error2[for=username]))") );
+	ok( form.is( ":has(span:visible:has(.error#username-error))" ) );
+	ok( form.is( ":has(span:visible:has(.error1#username-error))" ) );
+	ok( form.is( ":has(span:visible:has(.error2#username-error))" ) );
+	$( "#username" ).focus().trigger( "focusin" );
+	ok( !form.is( ":has(span:visible:has(.error#username-error))" ) );
+	ok( !form.is( ":has(span:visible:has(.error1#username-error))" ) );
+	ok( !form.is( ":has(span:visible:has(.error2#username-error))" ) );
 });
 
-test("elements() order", function() {
-	var container = $("#orderContainer"),
-		v = $("#elementsOrder").validate({
-			errorLabelContainer: container,
-			wrap: "li"
-		});
-
-	deepEqual( v.elements().map(function() {
-		return $(this).attr("id");
-	}).get(), ["order1", "order2", "order3", "order4", "order5", "order6"], "elements must be in document order" );
-	v.form();
-	deepEqual( container.children().map(function() {
-		return $(this).attr("for");
-	}).get(), ["order1", "order2", "order3", "order4", "order5", "order6"], "labels in error container must be in document order" );
+test( "defaultMessage(), empty title is ignored", function() {
+	var v = $( "#userForm" ).validate();
+	equal( "This field is required.", v.defaultMessage($( "#username" )[ 0 ], "required" ) );
 });
 
-test("defaultMessage(), empty title is ignored", function() {
-	var v = $("#userForm").validate();
-	equal( "This field is required.", v.defaultMessage($("#username")[0], "required") );
-});
+test( "formatAndAdd", function() {
+	expect( 4 );
+	var v = $( "#form" ).validate(),
+		fakeElement = { form: $( "#form" )[ 0 ], name: "bar" };
 
-test("formatAndAdd", function() {
-	expect(4);
-	var v = $("#form").validate(),
-		fakeElement = { form: $("#form")[0], name: "bar" };
+	v.formatAndAdd( fakeElement, {method: "maxlength", parameters: 2});
+	equal( "Please enter no more than 2 characters.", v.errorList[ 0 ].message );
+	equal( "bar", v.errorList[ 0 ].element.name );
 
-	v.formatAndAdd(fakeElement, {method: "maxlength", parameters: 2});
-	equal( "Please enter no more than 2 characters.", v.errorList[0].message );
-	equal( "bar", v.errorList[0].element.name );
-
-	v.formatAndAdd(fakeElement, {method: "range", parameters:[2,4]});
+	v.formatAndAdd( fakeElement, {method: "range", parameters:[2,4]});
 	equal( "Please enter a value between 2 and 4.", v.errorList[1].message );
 
-	v.formatAndAdd(fakeElement, {method: "range", parameters:[0,4]});
+	v.formatAndAdd( fakeElement, {method: "range", parameters:[0,4]});
 	equal( "Please enter a value between 0 and 4.", v.errorList[2].message );
 });
 
-test("formatAndAdd2", function() {
-	expect(3);
-	var v = $("#form").validate(),
-		fakeElement = { form: $("#form")[0], name: "bar" };
+test( "formatAndAdd2", function() {
+	expect( 3 );
+	var v = $( "#form" ).validate(),
+		fakeElement = { form: $( "#form" )[ 0 ], name: "bar" };
 
-	jQuery.validator.messages.test1 = function(param, element) {
+	jQuery.validator.messages.test1 = function( param, element ) {
 		equal( v, this );
 		equal( 0, param );
 		return "element " + element.name + " is not valid";
 	};
-	v.formatAndAdd(fakeElement, {method: "test1", parameters: 0});
-	equal( "element bar is not valid", v.errorList[0].message );
+	v.formatAndAdd( fakeElement, {method: "test1", parameters: 0});
+	equal( "element bar is not valid", v.errorList[ 0 ].message );
 });
 
-test("formatAndAdd, auto detect substitution string", function() {
-	var v = $("#testForm1clean").validate({
+test( "formatAndAdd, auto detect substitution string", function() {
+	var v = $( "#testForm1clean" ).validate({
 		rules: {
-			firstname: {
+			firstnamec: {
 				required: true,
 				rangelength: [5, 10]
 			}
 		},
 		messages: {
-			firstname: {
+			firstnamec: {
 				rangelength: "at least ${0}, up to {1}"
 			}
 		}
 	});
-	$("#firstnamec").val("abc");
+	$( "#firstnamec" ).val( "abc" );
 	v.form();
-	equal( "at least 5, up to 10", v.errorList[0].message );
+	equal( "at least 5, up to 10", v.errorList[ 0 ].message );
 });
 
-test("error containers, simple", function() {
-	expect(14);
-	var container = $("#simplecontainer"),
-		v = $("#form").validate({
-			errorLabelContainer: container,
-			showErrors: function() {
-				container.find("h3").html( jQuery.validator.format("There are {0} errors in your form.", this.size()) );
-				this.defaultShowErrors();
-			}
-		});
-
-	v.prepareForm();
-	ok( v.valid(), "form is valid" );
-	equal( 0, container.find("label").length, "There should be no error labels" );
-	equal( "", container.find("h3").html() );
-
-	v.prepareForm();
-	v.errorList = [{message:"bar", element: {name:"foo"}}, {message: "necessary", element: {name:"required"}}];
-	ok( !v.valid(), "form is not valid after adding errors manually" );
-	v.showErrors();
-	equal( container.find("label").length, 2, "There should be two error labels" );
-	ok( container.is(":visible"), "Check that the container is visible" );
-	container.find("label").each(function() {
-		ok( $(this).is(":visible"), "Check that each label is visible" );
-	});
-	equal( "There are 2 errors in your form.", container.find("h3").html() );
-
-	v.prepareForm();
-	ok( v.valid(), "form is valid after a reset" );
-	v.showErrors();
-	equal( container.find("label").length, 2, "There should still be two error labels" );
-	ok( container.is(":hidden"), "Check that the container is hidden" );
-	container.find("label").each(function() {
-		ok( $(this).is(":hidden"), "Check that each label is hidden" );
-	});
-});
-
-test("error containers, with labelcontainer I", function() {
-	expect(16);
-	var container = $("#container"),
-		labelcontainer = $("#labelcontainer"),
-		v = $("#form").validate({
-			errorContainer: container,
-			errorLabelContainer: labelcontainer,
-			wrapper: "li"
-		});
-
-	ok( v.valid(), "form is valid" );
-	equal( 0, container.find("label").length, "There should be no error labels in the container" );
-	equal( 0, labelcontainer.find("label").length, "There should be no error labels in the labelcontainer" );
-	equal( 0, labelcontainer.find("li").length, "There should be no lis labels in the labelcontainer" );
-
-	v.errorList = [{message:"bar", element: {name:"foo"}}, {name: "required", message: "necessary", element: {name:"required"}}];
-	ok( !v.valid(), "form is not valid after adding errors manually" );
-	v.showErrors();
-	equal( 0, container.find("label").length, "There should be no error label in the container" );
-	equal( 2, labelcontainer.find("label").length, "There should be two error labels in the labelcontainer" );
-	equal( 2, labelcontainer.find("li").length, "There should be two error lis in the labelcontainer" );
-	ok( container.is(":visible"), "Check that the container is visible" );
-	ok( labelcontainer.is(":visible"), "Check that the labelcontainer is visible" );
-	labelcontainer.find("label").each(function() {
-		ok( $(this).is(":visible"), "Check that each label is visible1" );
-		equal( "li", $(this).parent()[0].tagName.toLowerCase(), "Check that each label is wrapped in an li" );
-		ok( $(this).parent("li").is(":visible"), "Check that each parent li is visible" );
-	});
-});
-
-test("errorcontainer, show/hide only on submit", function() {
-	expect(14);
-	var container = $("#container"),
-		labelContainer = $("#labelcontainer"),
-		v = $("#testForm1").bind("invalid-form.validate", function() {
-			ok( true, "invalid-form event triggered called" );
-		}).validate({
-			errorContainer: container,
-			errorLabelContainer: labelContainer,
-			showErrors: function() {
-				container.html( jQuery.validator.format("There are {0} errors in your form.", this.numberOfInvalids()) );
-				ok( true, "showErrors called" );
-				this.defaultShowErrors();
-			}
-		});
-
-	equal( "", container.html(), "must be empty" );
-	equal( "", labelContainer.html(), "must be empty" );
-	// validate whole form, both showErrors and invalidHandler must be called once
-	// preferably invalidHandler first, showErrors second
-	ok( !v.form(), "invalid form" );
-	equal( 2, labelContainer.find("label").length );
-	equal( "There are 2 errors in your form.", container.html() );
-	ok( labelContainer.is(":visible"), "must be visible" );
-	ok( container.is(":visible"), "must be visible" );
-
-	$("#firstname").val("hix").keyup();
-	$("#testForm1").triggerHandler("keyup", [jQuery.event.fix({ type: "keyup", target: $("#firstname")[0] })]);
-	equal( 1, labelContainer.find("label:visible").length );
-	equal( "There are 1 errors in your form.", container.html() );
-
-	$("#lastname").val("abc");
-	ok( v.form(), "Form now valid, trigger showErrors but not invalid-form" );
-});
-
-asyncTest("option invalidHandler", function() {
-	expect(1);
-	$("#testForm1clean").validate({
+asyncTest( "option invalidHandler", function() {
+	expect( 1 );
+	$( "#testForm1clean" ).validate({
 		invalidHandler: function() {
 			ok( true, "invalid-form event triggered called" );
 			start();
 		}
 	});
-	$("#usernamec").val("asdf").rules("add", { required: true, minlength: 5 });
-	$("#testForm1clean").submit();
+	$( "#usernamec" ).val( "asdf" ).rules( "add", { required: true, minlength: 5 });
+	$( "#testForm1clean" ).submit();
 });
 
-test("findByName()", function() {
-	deepEqual( new $.validator({}, document.getElementById("form")).findByName(document.getElementById("radio1").name).get(), $("#form").find("[name=radio1]").get() );
+test( "findByName()", function() {
+	deepEqual(
+		new $.validator({}, document.getElementById( "form" ))
+			.findByName( document.getElementById( "radio1" ).name )
+			.get(),
+		$( "#form" ).find( "[name=radio1]" ).get()
+	);
 });
 
-test("focusInvalid()", function() {
+test( "focusInvalid()", function() {
 	// TODO when using custom focusin, this is triggered just once
 	// TODO when using 1.4 focusin, triggered twice; fix once not testing against 1.3 anymore
-	// expect(1);
-	var inputs = $("#testForm1 input").focus(function() {
-			equal( inputs[0], this, "focused first element" );
+	// expect( 1 );
+	var inputs = $( "#testForm1 input" ).focus(function() {
+			equal( inputs[ 0 ], this, "focused first element" );
 		}),
-		v = $("#testForm1").validate();
+		v = $( "#testForm1" ).validate();
 
 	v.form();
 	v.focusInvalid();
 });
 
-test("findLastActive()", function() {
-	expect(3);
-	var v = $("#testForm1").validate(),
+test( "findLastActive()", function() {
+	expect( 3 );
+	var v = $( "#testForm1" ).validate(),
 		lastActive;
 
 	ok( !v.findLastActive() );
 	v.form();
 	v.focusInvalid();
-	equal( v.findLastActive(), $("#firstname")[0] );
-	lastActive = $("#lastname").trigger("focus").trigger("focusin")[0];
+	equal( v.findLastActive(), $( "#firstname" )[ 0 ] );
+	lastActive = $( "#lastname" ).trigger( "focus" ).trigger( "focusin" )[ 0 ];
 
 	equal( v.lastActive, lastActive );
 });
 
-test("validating multiple checkboxes with 'required'", function() {
-	expect(3);
-	var checkboxes = $("#form input[name=check3]").prop("checked", false),
+test( "validating multiple checkboxes with 'required'", function() {
+	expect( 3 );
+	var checkboxes = $( "#form input[name=check3]" ).prop( "checked", false ),
 		v;
-	equal(checkboxes.size(), 5);
+	equal( checkboxes.size(), 5 );
 
-	v = $("#form").validate({
+	v = $( "#form" ).validate({
 		rules: {
 			check3: "required"
 		}
 	});
 	v.form();
 
-	equal(v.size(), 1);
-	checkboxes.filter(":last").prop("checked", true);
+	equal( v.size(), 1 );
+	checkboxes.filter( ":last" ).prop( "checked", true );
 	v.form();
-	equal(v.size(), 0);
+	equal( v.size(), 0 );
 });
 
-test("dynamic form", function() {
+test( "dynamic form", function() {
 	var counter = 0,
 		v;
 	function add() {
-		$("<input data-rule-required='true' name='list" + counter++ + "' />").appendTo("#testForm2");
+		$( "<input data-rule-required='true' name='list" + counter++ + "' />" ).appendTo( "#testForm2" );
 	}
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
 
-	v = $("#testForm2").validate();
+	v = $( "#testForm2" ).validate();
 	v.form();
-	errors(1);
+	errors( 1 );
 	add();
 	v.form();
-	errors(2);
+	errors( 2 );
 	add();
 	v.form();
-	errors(3);
-	$("#testForm2 input[name=list1]").remove();
+	errors( 3 );
+	$( "#testForm2 input[name=list1]" ).remove();
 	v.form();
-	errors(2);
+	errors( 2 );
 	add();
 	v.form();
-	errors(3);
-	$("#testForm2 input[name^=list]").remove();
+	errors( 3 );
+	$( "#testForm2 input[name^=list]" ).remove();
 	v.form();
-	errors(1);
-	$("#agb").attr("disabled", true);
+	errors( 1 );
+	$( "#agb" ).attr( "disabled", true );
 	v.form();
-	errors(0);
-	$("#agb").attr("disabled", false);
+	errors( 0 );
+	$( "#agb" ).attr( "disabled", false );
 	v.form();
-	errors(1);
+	errors( 1 );
 });
 
-test("idOrName()", function() {
-	expect(4);
-	var v = $("#testForm1").validate();
-	equal( "form8input", v.idOrName( $("#form8input")[0] ) );
-	equal( "check", v.idOrName( $("#form6check1")[0] ) );
-	equal( "agree", v.idOrName( $("#agb")[0] ) );
-	equal( "button", v.idOrName( $("#form :button")[0] ) );
+test( "idOrName()", function() {
+	expect( 4 );
+	var v = $( "#testForm1" ).validate();
+	equal( "form8input", v.idOrName( $( "#form8input" )[ 0 ] ) );
+	equal( "check", v.idOrName( $( "#form6check1" )[ 0 ] ) );
+	equal( "agree", v.idOrName( $( "#agb" )[ 0 ] ) );
+	equal( "button", v.idOrName( $( "#form :button" )[ 0 ] ) );
 });
 
-test("resetForm()", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "resetForm()", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	var v = $("#testForm1").validate();
+	var v = $( "#testForm1" ).validate();
 	v.form();
-	errors(2);
-	$("#firstname").val("hiy");
+	errors( 2 );
+	$( "#firstname" ).val( "hiy" );
 	v.resetForm();
-	errors(0);
-	equal("", $("#firstname").val(), "form plugin is included, therefor resetForm must also reset inputs, not only errors");
+	errors( 0 );
+	equal( "", $( "#firstname" ).val(), "form plugin is included, therefor resetForm must also reset inputs, not only errors" );
 });
 
-test("message from title", function() {
-	var v = $("#withTitle").validate();
+test( "message from title", function() {
+	var v = $( "#withTitle" ).validate();
 	v.checkForm();
-	equal(v.errorList[0].message, "fromtitle", "title not used");
+	equal( v.errorList[ 0 ].message, "fromtitle", "title not used" );
 });
 
-test("ignoreTitle", function() {
-	var v = $("#withTitle").validate({ignoreTitle:true});
+test( "ignoreTitle", function() {
+	var v = $( "#withTitle" ).validate({ ignoreTitle:true });
 	v.checkForm();
-	equal(v.errorList[0].message, $.validator.messages.required, "title used when it should have been ignored");
+	equal( v.errorList[ 0 ].message, $.validator.messages.required, "title used when it should have been ignored" );
 });
 
-asyncTest("ajaxSubmit", function() {
-	expect(1);
-	$("#user").val("Peter");
-	$("#password").val("foobar");
-	jQuery("#signupForm").validate({
-		submitHandler: function(form) {
-			jQuery(form).ajaxSubmit({
-				success: function(response) {
-					equal("Hi Peter, welcome back.", response);
+asyncTest( "ajaxSubmit", function() {
+	expect( 1 );
+	$( "#user" ).val( "Peter" );
+	$( "#password" ).val( "foobar" );
+	jQuery( "#signupForm" ).validate({
+		submitHandler: function( form ) {
+			jQuery( form ).ajaxSubmit({
+				success: function( response ) {
+					equal( "Hi Peter, welcome back.", response );
 					start();
 				}
 			});
 		}
 	});
-	jQuery("#signupForm").triggerHandler("submit");
+	jQuery( "#signupForm" ).triggerHandler( "submit" );
 });
 
-test("validating groups settings parameter", function() {
-	var form = $("<form>"),
+test( "validating groups settings parameter", function() {
+	var form = $( "<form>" ),
 		validate = form.validate({
 			groups: {
 				arrayGroup: ["input one", "input-two", "input three"],
@@ -887,111 +788,110 @@ test("validating groups settings parameter", function() {
 			}
 		});
 
-	equal(validate.groups["input one"], "arrayGroup");
-	equal(validate.groups["input-two"], "arrayGroup");
-	equal(validate.groups["input three"], "arrayGroup");
-	equal(validate.groups["input-four"], "stringGroup");
-	equal(validate.groups["input-five"], "stringGroup");
-	equal(validate.groups["input-six"], "stringGroup");
+	equal( validate.groups[ "input one" ], "arrayGroup" );
+	equal( validate.groups[ "input-two" ], "arrayGroup" );
+	equal( validate.groups[ "input three" ], "arrayGroup" );
+	equal( validate.groups[ "input-four" ], "stringGroup" );
+	equal( validate.groups[ "input-five" ], "stringGroup" );
+	equal( validate.groups[ "input-six" ], "stringGroup" );
 });
 
-test("bypassing validation on form submission",function () {
-	var form = $("#bypassValidation"),
-		normalSubmission = $("form#bypassValidation :input[id=normalSubmit]"),
-		bypassSubmitWithCancel = $("form#bypassValidation :input[id=bypassSubmitWithCancel]"),
-		bypassSubmitWithNoValidate1 = $("form#bypassValidation :input[id=bypassSubmitWithNoValidate1]"),
-		bypassSubmitWithNoValidate2 = $("form#bypassValidation :input[id=bypassSubmitWithNoValidate2]"),
+test( "bypassing validation on form submission",function () {
+	var form = $( "#bypassValidation" ),
+		normalSubmission = $( "form#bypassValidation :input[id=normalSubmit]" ),
+		bypassSubmitWithCancel = $( "form#bypassValidation :input[id=bypassSubmitWithCancel]" ),
+		bypassSubmitWithNoValidate1 = $( "form#bypassValidation :input[id=bypassSubmitWithNoValidate1]" ),
+		bypassSubmitWithNoValidate2 = $( "form#bypassValidation :input[id=bypassSubmitWithNoValidate2]" ),
 		$v = form.validate({
 			debug : true
 		});
 
 	bypassSubmitWithCancel.click();
-	equal($v.numberOfInvalids(), 0, "Validation was bypassed using CSS 'cancel' class.");
+	equal($v.numberOfInvalids(), 0, "Validation was bypassed using CSS 'cancel' class." );
 	$v.resetForm();
 
 	bypassSubmitWithNoValidate1.click();
-	equal($v.numberOfInvalids(), 0, "Validation was bypassed using blank 'formnovalidate' attribute.");
+	equal($v.numberOfInvalids(), 0, "Validation was bypassed using blank 'formnovalidate' attribute." );
 	$v.resetForm();
 
 	bypassSubmitWithNoValidate2.click();
-	equal($v.numberOfInvalids(), 0, "Validation was bypassed using 'formnovalidate=\"formnovalidate\"' attribute.");
+	equal($v.numberOfInvalids(), 0, "Validation was bypassed using 'formnovalidate=\"formnovalidate\"' attribute." );
 	$v.resetForm();
 
 	normalSubmission.click();
-	equal($v.numberOfInvalids(), 1, "Validation failed correctly");
+	equal($v.numberOfInvalids(), 1, "Validation failed correctly" );
 });
 
 
-module("misc");
+module( "misc" );
 
-test("success option", function() {
-	expect(7);
-	equal( "", $("#firstname").val() );
-	var v = $("#testForm1").validate({
+test( "success option", function() {
+	expect( 7 );
+	equal( "", $( "#firstname" ).val() );
+	var v = $( "#testForm1" ).validate({
 			success: "valid"
 		}),
-		label = $("#testForm1 label");
+		label = $( "#testForm1 .error:not(input)" );
 
-	ok( label.is(".error") );
-	ok( !label.is(".valid") );
+	ok( label.is( ".error" ) );
+	ok( !label.is( ".valid" ) );
 	v.form();
-	ok( label.is(".error") );
-	ok( !label.is(".valid") );
-	$("#firstname").val("hi");
+	ok( label.is( ".error" ) );
+	ok( !label.is( ".valid" ) );
+	$( "#firstname" ).val( "hi" );
 	v.form();
-	ok( label.is(".error") );
-	ok( label.is(".valid") );
+	ok( label.is( ".error" ) );
+	ok( label.is( ".valid" ) );
 });
 
-test("success option2", function() {
-	expect(5);
-	equal( "", $("#firstname").val() );
-	var v = $("#testForm1").validate({
+test( "success option2", function() {
+	expect( 5 );
+	equal( "", $( "#firstname" ).val() );
+	var v = $( "#testForm1" ).validate({
 			success: "valid"
 		}),
-		label = $("#testForm1 label");
+		label = $( "#testForm1 .error:not(input)" );
 
-	ok( label.is(".error") );
-	ok( !label.is(".valid") );
-	$("#firstname").val("hi");
+	ok( label.is( ".error" ) );
+	ok( !label.is( ".valid" ) );
+	$( "#firstname" ).val( "hi" );
 	v.form();
-	ok( label.is(".error") );
-	ok( label.is(".valid") );
+	ok( label.is( ".error" ) );
+	ok( label.is( ".valid" ) );
 });
 
-test("success option3", function() {
-	expect(5);
-	equal( "", $("#firstname").val() );
-	$("#errorFirstname").remove();
-	var v = $("#testForm1").validate({
+test( "success option3", function() {
+	expect( 5 );
+	equal( "", $( "#firstname" ).val() );
+	$( "#errorFirstname" ).remove();
+	var v = $( "#testForm1" ).validate({
 			success: "valid"
 		}),
 		labels;
 
-	equal( 0, $("#testForm1 label").size() );
-	$("#firstname").val("hi");
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
+	$( "#firstname" ).val( "hi" );
 	v.form();
-	labels = $("#testForm1 label");
+	labels = $( "#testForm1 .error:not(input)" );
 
 	equal( 3, labels.size() );
-	ok( labels.eq(0).is(".valid") );
-	ok( !labels.eq(1).is(".valid") );
+	ok( labels.eq( 0 ).is( ".valid" ) );
+	ok( !labels.eq( 1 ).is( ".valid" ) );
 });
 
-test("successlist", function() {
-	var v = $("#form").validate({ success: "xyz" });
+test( "successlist", function() {
+	var v = $( "#form" ).validate({ success: "xyz" });
 	v.form();
-	equal(0, v.successList.length);
+	equal( 0, v.successList.length );
 });
 
-
-test("success isn't called for optional elements with no other rules", function() {
-	expect(4);
-	equal( "", $("#firstname").removeAttr("data-rule-required").removeAttr("data-rule-minlength").val() );
-	$("#something").remove();
-	$("#lastname").remove();
-	$("#errorFirstname").remove();
-	var v = $("#testForm1").validate({
+test( "success isn't called for optional elements with no other rules", function() {
+	expect( 4 );
+	equal( "", $( "#firstname" ).removeAttr( "data-rule-required" ).removeAttr( "data-rule-minlength" ).val() );
+	$( "#something" ).remove();
+	$( "#lastname" ).remove();
+	$( "#errorFirstname" ).remove();
+	var v = $( "#testForm1" ).validate({
 		success: function() {
 			ok( false, "don't call success for optional elements!" );
 		},
@@ -999,112 +899,118 @@ test("success isn't called for optional elements with no other rules", function(
 			firstname: { required: false }
 		}
 	});
-	equal( 0, $("#testForm1 label").size() );
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
 	v.form();
-	equal( 0, $("#testForm1 label").size() );
-	$("#firstname").valid();
-	equal( 0, $("#testForm1 label").size() );
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
+	$( "#firstname" ).valid();
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
 });
 
-test("success is called for optional elements with other rules", function() {
-	expect(1);
+test( "success is called for optional elements with other rules", function() {
+	expect( 1 );
 
-	$.validator.addMethod("custom1", function() {
+	$.validator.addMethod( "custom1", function() {
 		return true;
-	}, "");
+	}, "" );
 
-	$("#testForm1clean").validate({
+	$( "#testForm1clean" ).validate({
 		success: function() {
 			ok( true, "success called correctly!" );
 		},
 		rules: {
-			firstname: {
+			firstnamec: {
 				required: false,
 				custom1: true
 			}
 		}
 	});
 
-	$("#firstnamec").valid();
+	$( "#firstnamec" ).valid();
 
 	delete $.validator.methods.custom1;
 });
 
 
-test("success callback with element", function() {
-	expect(1);
-	var v = $("#userForm").validate({
+test( "success callback with element", function() {
+	expect( 1 );
+	var v = $( "#userForm" ).validate({
 		success: function( label, element ) {
-			equal( element, $("#username").get(0) );
+			equal( element, $( "#username" ).get( 0 ) );
 		}
 	});
-	$("#username").val("hi");
+	$( "#username" ).val( "hi" );
 	v.form();
 });
 
-test("all rules are evaluated even if one returns a dependency-mistmatch", function() {
-	expect(6);
-	equal( "", $("#firstname").removeAttr("data-rule-required").removeAttr("data-rule-minlength").val() );
-	$("#lastname").remove();
-	$("#errorFirstname").remove();
-	$.validator.addMethod("custom1", function() {
+test( "all rules are evaluated even if one returns a dependency-mistmatch", function() {
+	expect( 6 );
+	equal( "", $( "#firstname" ).removeAttr( "data-rule-required" ).removeAttr( "data-rule-minlength" ).val() );
+	$( "#lastname" ).remove();
+	$( "#errorFirstname" ).remove();
+	$.validator.addMethod( "custom1", function() {
 		ok( true, "custom method must be evaluated" );
 		return true;
-	}, "");
-	var v = $("#testForm1").validate({
+	}, "" );
+	var v = $( "#testForm1" ).validate({
 		rules: {
 			firstname: {email:true, custom1: true}
 		}
 	});
-	equal( 0, $("#testForm1 label").size() );
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
 	v.form();
-	equal( 0, $("#testForm1 label").size() );
-	$("#firstname").valid();
-	equal( 0, $("#testForm1 label").size() );
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
+	$( "#firstname" ).valid();
+	equal( 0, $( "#testForm1 .error:not(input)" ).size() );
 
 	delete $.validator.methods.custom1;
 	delete $.validator.messages.custom1;
 });
 
-test("messages", function() {
+test( "messages", function() {
 	var m = jQuery.validator.messages;
-	equal( "Please enter no more than 0 characters.", m.maxlength(0) );
-	equal( "Please enter at least 1 characters.", m.minlength(1) );
+	equal( "Please enter no more than 0 characters.", m.maxlength( 0 ) );
+	equal( "Please enter at least 1 characters.", m.minlength( 1 ) );
 	equal( "Please enter a value between 1 and 2 characters long.", m.rangelength([1, 2]) );
-	equal( "Please enter a value less than or equal to 1.", m.max(1) );
-	equal( "Please enter a value greater than or equal to 0.", m.min(0) );
+	equal( "Please enter a value less than or equal to 1.", m.max( 1 ) );
+	equal( "Please enter a value greater than or equal to 0.", m.min( 0 ) );
 	equal( "Please enter a value between 1 and 2.", m.range([1, 2]) );
 });
 
-test("jQuery.validator.format", function() {
-	equal( "Please enter a value between 0 and 1.", jQuery.validator.format("Please enter a value between {0} and {1}.", 0, 1) );
-	equal( "0 is too fast! Enter a value smaller then 0 and at least -15", jQuery.validator.format("{0} is too fast! Enter a value smaller then {0} and at least {1}", 0, -15) );
-	var template = jQuery.validator.format("{0} is too fast! Enter a value smaller then {0} and at least {1}");
-	equal( "0 is too fast! Enter a value smaller then 0 and at least -15", template(0, -15) );
-	template = jQuery.validator.format("Please enter a value between {0} and {1}.");
-	equal( "Please enter a value between 1 and 2.", template([1, 2]) );
-	equal( $.validator.format("{0}", "$0"), "$0" );
+test( "jQuery.validator.format", function() {
+	equal(
+		"Please enter a value between 0 and 1.",
+		jQuery.validator.format( "Please enter a value between {0} and {1}.", 0, 1 )
+	);
+	equal(
+		"0 is too fast! Enter a value smaller then 0 and at least -15",
+		jQuery.validator.format( "{0} is too fast! Enter a value smaller then {0} and at least {1}", 0, -15 )
+	);
+	var template = jQuery.validator.format( "{0} is too fast! Enter a value smaller then {0} and at least {1}" );
+	equal( "0 is too fast! Enter a value smaller then 0 and at least -15", template( 0, -15 ) );
+	template = jQuery.validator.format( "Please enter a value between {0} and {1}." );
+	equal( "Please enter a value between 1 and 2.", template( [ 1, 2 ] ) );
+	equal( $.validator.format( "{0}", "$0" ), "$0" );
 });
 
-test("option: ignore", function() {
-	var v = $("#testForm1").validate({
+test( "option: ignore", function() {
+	var v = $( "#testForm1" ).validate({
 		ignore: "[name=lastname]"
 	});
 	v.form();
 	equal( 1, v.size() );
 });
 
-test("option: subformRequired", function() {
-	jQuery.validator.addMethod("billingRequired", function(value, element) {
-		if ($("#bill_to_co").is(":checked")) {
-			return $(element).parents("#subform").length;
+test( "option: subformRequired", function() {
+	jQuery.validator.addMethod( "billingRequired", function( value, element ) {
+		if ($( "#bill_to_co" ).is( ":checked" )) {
+			return $( element ).parents( "#subform" ).length;
 		}
-		return !this.optional(element);
-	}, "");
-	var v = $("#subformRequired").validate();
+		return !this.optional( element );
+	}, "" );
+	var v = $( "#subformRequired" ).validate();
 	v.form();
 	equal( 1, v.size() );
-	$("#bill_to_co").attr("checked", false);
+	$( "#bill_to_co" ).attr( "checked", false );
 	v.form();
 	equal( 2, v.size() );
 
@@ -1112,204 +1018,204 @@ test("option: subformRequired", function() {
 	delete $.validator.messages.billingRequired;
 });
 
-module("expressions");
+module( "expressions" );
 
-test("expression: :blank", function() {
-	var e = $("#lastname")[0];
-	equal( 1, $(e).filter(":blank").length );
+test( "expression: :blank", function() {
+	var e = $( "#lastname" )[ 0 ];
+	equal( 1, $( e ).filter( ":blank" ).length );
 	e.value = " ";
-	equal( 1, $(e).filter(":blank").length );
+	equal( 1, $( e ).filter( ":blank" ).length );
 	e.value = "   ";
-	equal( 1, $(e).filter(":blank").length );
+	equal( 1, $( e ).filter( ":blank" ).length );
 	e.value= " a ";
-	equal( 0, $(e).filter(":blank").length );
+	equal( 0, $( e ).filter( ":blank" ).length );
 });
 
-test("expression: :filled", function() {
-	var e = $("#lastname")[0];
-	equal( 0, $(e).filter(":filled").length );
+test( "expression: :filled", function() {
+	var e = $( "#lastname" )[ 0 ];
+	equal( 0, $( e ).filter( ":filled" ).length );
 	e.value = " ";
-	equal( 0, $(e).filter(":filled").length );
+	equal( 0, $( e ).filter( ":filled" ).length );
 	e.value = "   ";
-	equal( 0, $(e).filter(":filled").length );
+	equal( 0, $( e ).filter( ":filled" ).length );
 	e.value= " a ";
-	equal( 1, $(e).filter(":filled").length );
+	equal( 1, $( e ).filter( ":filled" ).length );
 });
 
-test("expression: :unchecked", function() {
-	var e = $("#check2")[0];
-	equal( 1, $(e).filter(":unchecked").length );
+test( "expression: :unchecked", function() {
+	var e = $( "#check2" )[ 0 ];
+	equal( 1, $( e ).filter( ":unchecked" ).length );
 	e.checked = true;
-	equal( 0, $(e).filter(":unchecked").length );
+	equal( 0, $( e ).filter( ":unchecked" ).length );
 	e.checked = false;
-	equal( 1, $(e).filter(":unchecked").length );
+	equal( 1, $( e ).filter( ":unchecked" ).length );
 });
 
-module("events");
+module( "events" );
 
-test("validate on blur", function() {
-	function errors(expected, message) {
-		equal(v.size(), expected, message );
+test( "validate on blur", function() {
+	function errors( expected, message ) {
+		equal( v.size(), expected, message );
 	}
-	function labels(expected) {
-		equal(v.errors().filter(":visible").size(), expected);
+	function labels( expected ) {
+		equal( v.errors().filter( ":visible" ).size(), expected );
 	}
-	function blur(target) {
-		target.trigger("blur").trigger("focusout");
+	function blur( target ) {
+		target.trigger( "blur" ).trigger( "focusout" );
 	}
-	$("#errorFirstname").hide();
-	var e = $("#firstname"),
-		v = $("#testForm1").validate();
+	$( "#errorFirstname" ).hide();
+	var e = $( "#firstname" ),
+		v = $( "#testForm1" ).validate();
 
-	$("#something").val("");
-	blur(e);
-	errors(0, "No value yet, required is skipped on blur");
-	labels(0);
-	e.val("h");
-	blur(e);
-	errors(1, "Required was ignored, but as something was entered, check other rules, minlength isn't met");
-	labels(1);
-	e.val("hh");
-	blur(e);
-	errors(0, "All is fine");
-	labels(0);
-	e.val("");
+	$( "#something" ).val( "" );
+	blur( e );
+	errors( 0, "No value yet, required is skipped on blur" );
+	labels( 0 );
+	e.val( "h" );
+	blur( e );
+	errors( 1, "Required was ignored, but as something was entered, check other rules, minlength isn't met" );
+	labels( 1 );
+	e.val( "hh" );
+	blur( e );
+	errors( 0, "All is fine" );
+	labels( 0 );
+	e.val( "" );
 	v.form();
-	errors(3, "Submit checks all rules, both fields invalid");
-	labels(3);
-	blur(e);
-	errors(1, "Blurring the field results in emptying the error list first, then checking the invalid field: its still invalid, don't remove the error" );
-	labels(3);
-	e.val("h");
-	blur(e);
-	errors(1, "Entering a single character fulfills required, but not minlength: 2, still invalid");
-	labels(3);
-	e.val("hh");
-	blur(e);
-	errors(0, "Both required and minlength are met, no errors left");
-	labels(2);
+	errors( 3, "Submit checks all rules, both fields invalid" );
+	labels( 3 );
+	blur( e );
+	errors( 1, "Blurring the field results in emptying the error list first, then checking the invalid field: its still invalid, don't remove the error" );
+	labels( 3 );
+	e.val( "h" );
+	blur( e );
+	errors( 1, "Entering a single character fulfills required, but not minlength: 2, still invalid" );
+	labels( 3 );
+	e.val( "hh" );
+	blur( e );
+	errors( 0, "Both required and minlength are met, no errors left" );
+	labels( 2 );
 });
 
-test("validate on keyup", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate on keyup", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	function keyup(target) {
-		target.trigger("keyup");
+	function keyup( target ) {
+		target.trigger( "keyup" );
 	}
-	var e = $("#firstname"),
-		v = $("#testForm1").validate();
+	var e = $( "#firstname" ),
+		v = $( "#testForm1" ).validate();
 
-	keyup(e);
-	errors(0, "No value, no errors");
-	e.val("a");
-	keyup(e);
-	errors(0, "Value, but not invalid");
-	e.val("");
+	keyup( e );
+	errors( 0, "No value, no errors" );
+	e.val( "a" );
+	keyup( e );
+	errors( 0, "Value, but not invalid" );
+	e.val( "" );
 	v.form();
-	errors(2, "Both invalid");
-	keyup(e);
-	errors(1, "Only one field validated, still invalid");
-	e.val("hh");
-	keyup(e);
-	errors(0, "Not invalid anymore");
-	e.val("h");
-	keyup(e);
-	errors(1, "Field didn't loose focus, so validate again, invalid");
-	e.val("hh");
-	keyup(e);
-	errors(0, "Valid");
+	errors( 2, "Both invalid" );
+	keyup( e );
+	errors( 1, "Only one field validated, still invalid" );
+	e.val( "hh" );
+	keyup( e );
+	errors( 0, "Not invalid anymore" );
+	e.val( "h" );
+	keyup( e );
+	errors( 1, "Field didn't loose focus, so validate again, invalid" );
+	e.val( "hh" );
+	keyup( e );
+	errors( 0, "Valid" );
 });
 
-test("validate on not keyup, only blur", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate on not keyup, only blur", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	var e = $("#firstname"),
-		v = $("#testForm1").validate({
+	var e = $( "#firstname" ),
+		v = $( "#testForm1" ).validate({
 			onkeyup: false
 		});
 
-	errors(0);
-	e.val("a");
-	e.trigger("keyup");
+	errors( 0 );
+	e.val( "a" );
+	e.trigger( "keyup" );
 	e.keyup();
-	errors(0);
-	e.trigger("blur").trigger("focusout");
-	errors(1);
+	errors( 0 );
+	e.trigger( "blur" ).trigger( "focusout" );
+	errors( 1 );
 });
 
-test("validate on keyup and blur", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate on keyup and blur", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	var e = $("#firstname"),
-		v = $("#testForm1").validate();
+	var e = $( "#firstname" ),
+		v = $( "#testForm1" ).validate();
 
-	errors(0);
-	e.val("a");
-	e.trigger("keyup");
-	errors(0);
-	e.trigger("blur").trigger("focusout");
-	errors(1);
+	errors( 0 );
+	e.val( "a" );
+	e.trigger( "keyup" );
+	errors( 0 );
+	e.trigger( "blur" ).trigger( "focusout" );
+	errors( 1 );
 });
 
-test("validate email on keyup and blur", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate email on keyup and blur", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	var e = $("#firstname"),
-		v = $("#testForm1").validate();
+	var e = $( "#firstname" ),
+		v = $( "#testForm1" ).validate();
 
 	v.form();
-	errors(2);
-	e.val("a");
-	e.trigger("keyup");
-	errors(1);
-	e.val("aa");
-	e.trigger("keyup");
-	errors(0);
+	errors( 2 );
+	e.val( "a" );
+	e.trigger( "keyup" );
+	errors( 1 );
+	e.val( "aa" );
+	e.trigger( "keyup" );
+	errors( 0 );
 });
 
-test("validate checkbox on click", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate checkbox on click", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	function trigger(element) {
+	function trigger( element ) {
 		element.click();
 		// triggered click event screws up checked-state in 1.4
 		element.valid();
 	}
-	var e = $("#check2"),
-		v = $("#form").validate({
+	var e = $( "#check2" ),
+		v = $( "#form" ).validate({
 			rules: {
 				check2: "required"
 			}
 		});
 
-	trigger(e);
-	errors(0);
-	trigger(e);
+	trigger( e );
+	errors( 0 );
+	trigger( e );
 	equal( false, v.form() );
-	errors(1);
-	trigger(e);
-	errors(0);
-	trigger(e);
-	errors(1);
+	errors( 1 );
+	trigger( e );
+	errors( 0 );
+	trigger( e );
+	errors( 1 );
 });
 
-test("validate multiple checkbox on click", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate multiple checkbox on click", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	function trigger(element) {
+	function trigger( element ) {
 		element.click();
 		// triggered click event screws up checked-state in 1.4
 		element.valid();
 	}
-	var e1 = $("#check1").attr("checked", false),
-		e2 = $("#check1b"),
-		v = $("#form").validate({
+	var e1 = $( "#check1" ).attr( "checked", false ),
+		e2 = $( "#check1b" ),
+		v = $( "#form" ).validate({
 			rules: {
 				check: {
 					required: true,
@@ -1318,29 +1224,29 @@ test("validate multiple checkbox on click", function() {
 			}
 		});
 
-	trigger(e1);
-	trigger(e2);
-	errors(0);
-	trigger(e2);
+	trigger( e1 );
+	trigger( e2 );
+	errors( 0 );
+	trigger( e2 );
 	equal( false, v.form() );
-	errors(1);
-	trigger(e2);
-	errors(0);
-	trigger(e2);
-	errors(1);
+	errors( 1 );
+	trigger( e2 );
+	errors( 0 );
+	trigger( e2 );
+	errors( 1 );
 });
 
-test("correct checkbox receives the error", function(){
-	function trigger(element) {
+test( "correct checkbox receives the error", function(){
+	function trigger( element ) {
 		element.click();
 		// triggered click event screws up checked-state in 1.4
 		element.valid();
 	}
-	var e1 = $("#check1").attr("checked", false),
+	var e1 = $( "#check1" ).attr( "checked", false ),
 		v;
 
-	$("#check1b").attr("checked", false);
-	v = $("#form").find("[type=checkbox]").attr("checked", false).end().validate({
+	$( "#check1b" ).attr( "checked", false );
+	v = $( "#form" ).find( "[type=checkbox]" ).attr( "checked", false ).end().validate({
 		rules:{
 			check: {
 					required: true,
@@ -1349,241 +1255,241 @@ test("correct checkbox receives the error", function(){
 		}
 	});
 
-	equal(false, v.form());
-	trigger(e1);
-	equal(false, v.form());
-	ok(v.errorList[0].element.id === v.currentElements[0].id, "the proper checkbox has the error AND is present in currentElements");
+	equal( false, v.form());
+	trigger( e1 );
+	equal( false, v.form());
+	ok( v.errorList[ 0 ].element.id === v.currentElements[ 0 ].id, "the proper checkbox has the error AND is present in currentElements" );
 });
 
-test("validate radio on click", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate radio on click", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	function trigger(element) {
+	function trigger( element ) {
 		element.click();
 		// triggered click event screws up checked-state in 1.4
 		element.valid();
 	}
-	var e1 = $("#radio1"),
-		e2 = $("#radio1a"),
-		v = $("#form").validate({
+	var e1 = $( "#radio1" ),
+		e2 = $( "#radio1a" ),
+		v = $( "#form" ).validate({
 			rules: {
 				radio1: "required"
 			}
 		});
 
-	errors(0);
+	errors( 0 );
 	equal( false, v.form() );
-	errors(1);
-	trigger(e2);
-	errors(0);
-	trigger(e1);
-	errors(0);
+	errors( 1 );
+	trigger( e2 );
+	errors( 0 );
+	trigger( e1 );
+	errors( 0 );
 });
 
-test("validate input with no type attribute, defaulting to text", function() {
-	function errors(expected, message) {
-		equal(expected, v.size(), message );
+test( "validate input with no type attribute, defaulting to text", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
 	}
-	var v = $("#testForm12").validate(),
-		e = $("#testForm12text");
+	var v = $( "#testForm12" ).validate(),
+		e = $( "#testForm12text" );
 
-	errors(0);
+	errors( 0 );
 	e.valid();
-	errors(1);
-	e.val("test");
-	e.trigger("keyup");
-	errors(0);
+	errors( 1 );
+	e.val( "test" );
+	e.trigger( "keyup" );
+	errors( 0 );
 });
 
-test("ignore hidden elements", function(){
-	var form = $("#userForm"),
+test( "ignore hidden elements", function(){
+	var form = $( "#userForm" ),
 		validate = form.validate({
 			rules:{
 				"username": "required"
 			}
 		});
 
-	form.get(0).reset();
-	ok(! validate.form(), "form should be initially invalid");
-	$("#userForm [name=username]").hide();
-	ok(validate.form(), "hidden elements should be ignored by default");
+	form.get( 0 ).reset();
+	ok(! validate.form(), "form should be initially invalid" );
+	$( "#userForm [name=username]" ).hide();
+	ok( validate.form(), "hidden elements should be ignored by default" );
 });
 
-test("ignore hidden elements at start", function(){
-	var form = $("#userForm"),
+test( "ignore hidden elements at start", function(){
+	var form = $( "#userForm" ),
 		validate = form.validate({
 			rules:{
 				"username": "required"
 			}
 		});
 
-	form.get(0).reset();
-	$("#userForm [name=username]").hide();
-	ok(validate.form(), "hidden elements should be ignored by default");
-	$("#userForm [name=username]").show();
-	ok(! validate.form(), "form should be invalid when required element is visible");
+	form.get( 0 ).reset();
+	$( "#userForm [name=username]" ).hide();
+	ok( validate.form(), "hidden elements should be ignored by default" );
+	$( "#userForm [name=username]" ).show();
+	ok(! validate.form(), "form should be invalid when required element is visible" );
 });
 
-test("Specify error messages through data attributes", function() {
-	var form = $("#dataMessages"),
-		name = $("#dataMessagesName"),
+test( "Specify error messages through data attributes", function() {
+	var form = $( "#dataMessages" ),
+		name = $( "#dataMessagesName" ),
 		label;
 
 	form.validate();
 
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#dataMessages label");
+	label = $( "#dataMessages .error:not(input)" );
 	equal( label.text(), "You must enter a value here", "Correct error label" );
 });
 
-test("Updates pre-existing label if has error class", function() {
-	var form = $("#updateLabel"),
-		input = $("#updateLabelInput"),
-		label = $("#targetLabel"),
-		labelsBefore = form.find("label").length,
+test( "Updates pre-existing label if has error class", function() {
+	var form = $( "#updateLabel" ),
+		input = $( "#updateLabelInput" ),
+		label = $( "#targetLabel" ),
+		labelsBefore = form.find( ".error:not(input)" ).length,
 		labelsAfter;
 
 	form.validate();
-	input.val("");
+	input.val( "" );
 	input.valid();
-	labelsAfter = form.find("label").length;
+	labelsAfter = form.find( ".error:not(input)" ).length;
 
 	// label was updated
-	equal( label.text(), input.attr("data-msg-required") );
-	// new label wasn"t created
+	equal( label.text(), input.attr( "data-msg-required" ) );
+	// new label wasn't created
 	equal( labelsBefore, labelsAfter );
 });
 
-test("Min date set by attribute", function() {
-	var form = $("#rangesMinDateInvalid"),
-		name = $("#minDateInvalid"),
+test( "Min date set by attribute", function() {
+	var form = $( "#rangesMinDateInvalid" ),
+		name = $( "#minDateInvalid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#rangesMinDateInvalid label");
+	label = $( "#rangesMinDateInvalid .error:not(input)" );
 	equal( label.text(), "Please enter a value greater than or equal to 2012-12-21.", "Correct error label" );
 });
 
-test("Max date set by attribute", function() {
-	var form = $("#ranges"),
-		name = $("#maxDateInvalid"),
+test( "Max date set by attribute", function() {
+	var form = $( "#ranges" ),
+		name = $( "#maxDateInvalid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value less than or equal to 2012-12-21.", "Correct error label" );
 });
 
-test("Min and Max date set by attributes greater", function() {
-	var form = $("#ranges"),
-		name = $("#rangeDateInvalidGreater"),
+test( "Min and Max date set by attributes greater", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeDateInvalidGreater" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value less than or equal to 2013-01-21.", "Correct error label" );
 });
 
-test("Min and Max date set by attributes less", function() {
-	var form = $("#ranges"),
-		name = $("#rangeDateInvalidLess"),
+test( "Min and Max date set by attributes less", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeDateInvalidLess" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value greater than or equal to 2012-11-21.", "Correct error label" );
 });
 
-test("Min date set by attribute valid", function() {
-	var form = $("#rangeMinDateValid"),
-		name = $("#minDateValid"),
+test( "Min date set by attribute valid", function() {
+	var form = $( "#rangeMinDateValid" ),
+		name = $( "#minDateValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#rangeMinDateValid label");
+	label = $( "#rangeMinDateValid .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
-test("Max date set by attribute valid", function() {
-	var form = $("#ranges"),
-		name = $("#maxDateValid"),
+test( "Max date set by attribute valid", function() {
+	var form = $( "#ranges" ),
+		name = $( "#maxDateValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
-test("Min and Max date set by attributes valid", function() {
-	var form = $("#ranges"),
-		name = $("#rangeDateValid"),
+test( "Min and Max date set by attributes valid", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeDateValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
-test("Min and Max strings set by attributes greater", function() {
-	var form = $("#ranges"),
-		name = $("#rangeTextInvalidGreater"),
+test( "Min and Max strings set by attributes greater", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeTextInvalidGreater" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value less than or equal to 200.", "Correct error label" );
 });
 
-test("Min and Max strings set by attributes less", function() {
-	var form = $("#ranges"),
-		name = $("#rangeTextInvalidLess"),
+test( "Min and Max strings set by attributes less", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeTextInvalidLess" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value greater than or equal to 200.", "Correct error label" );
 });
 
-test("Min and Max strings set by attributes valid", function() {
-	var form = $("#ranges"),
-		name = $("#rangeTextValid"),
+test( "Min and Max strings set by attributes valid", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeTextValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
@@ -1603,48 +1509,48 @@ test( "calling blur on ignored element", function() {
 });
 
 
-test("Min and Max type absent set by attributes greater", function() {
-	var form = $("#ranges"),
-		name = $("#rangeAbsentInvalidGreater"),
+test( "Min and Max type absent set by attributes greater", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeAbsentInvalidGreater" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value less than or equal to 200.", "Correct error label" );
 });
 
-test("Min and Max type absent set by attributes less", function() {
-	var form = $("#ranges"),
-		name = $("#rangeAbsentInvalidLess"),
+test( "Min and Max type absent set by attributes less", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeAbsentInvalidLess" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value greater than or equal to 200.", "Correct error label" );
 });
 
-test("Min and Max type absent set by attributes valid", function() {
-	var form = $("#ranges"),
-		name = $("#rangeAbsentValid"),
+test( "Min and Max type absent set by attributes valid", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeAbsentValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
 
 
-test("Min and Max range set by attributes valid", function() {
+test( "Min and Max range set by attributes valid", function() {
 	//
 	// cannot test for overflow:
 	// When the element is suffering from an underflow,
@@ -1652,95 +1558,95 @@ test("Min and Max range set by attributes valid", function() {
 	// floating-point number that represents the minimum.
 	// http://www.w3.org/TR/html5/forms.html#range-state-%28type=range%29
 	//
-	var form = $("#ranges"),
-		name = $("#rangeRangeValid"),
+	var form = $( "#ranges" ),
+		name = $( "#rangeRangeValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
 
-test("Min and Max number set by attributes valid", function() {
-	var form = $("#ranges"),
-		name = $("#rangeNumberValid"),
+test( "Min and Max number set by attributes valid", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeNumberValid" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
 
-test("Min and Max number set by attributes greater", function() {
-	var form = $("#ranges"),
-		name = $("#rangeNumberInvalidGreater"),
+test( "Min and Max number set by attributes greater", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeNumberInvalidGreater" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value less than or equal to 200.", "Correct error label" );
 });
 
 
-test("Min and Max number set by attributes less", function() {
-	var form = $("#ranges"),
-		name = $("#rangeNumberInvalidLess"),
+test( "Min and Max number set by attributes less", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeNumberInvalidLess" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value greater than or equal to 50.", "Correct error label" );
 });
 
-test("Rules allowed to have a value of zero invalid", function() {
-	var form = $("#ranges"),
-		name = $("#rangeMinZeroInvalidLess"),
+test( "Rules allowed to have a value of zero invalid", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeMinZeroInvalidLess" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "Please enter a value greater than or equal to 0.", "Correct error label" );
 });
 
-test("Rules allowed to have a value of zero valid equal", function() {
-	var form = $("#ranges"),
-		name = $("#rangeMinZeroValidEqual"),
+test( "Rules allowed to have a value of zero valid equal", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeMinZeroValidEqual" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });
 
-test("Rules allowed to have a value of zero valid greater", function() {
-	var form = $("#ranges"),
-		name = $("#rangeMinZeroValidGreater"),
+test( "Rules allowed to have a value of zero valid greater", function() {
+	var form = $( "#ranges" ),
+		name = $( "#rangeMinZeroValidGreater" ),
 		label;
 
 	form.validate();
-	form.get(0).reset();
+	form.get( 0 ).reset();
 	name.valid();
 
-	label = $("#ranges label");
+	label = $( "#ranges .error:not(input)" );
 	equal( label.text(), "", "Correct error label" );
 });


### PR DESCRIPTION
Non-label error labels will now work correctly, with `aria-describedby` now superseding dependency on the 'for' attribute

This provides a solution to the discussion noted in #900.

A lot of work had to be done to rewrite the test cases to respect the 'span' error label... apologies if I have made any incorrect assumptions about this module.

For legacy reasons, if the error element is set as a label explicitly, it still sets the 'for' attribute, but it isn't used anywhere in the module.
