### PR TITLE
Fixing issues #922 and #858

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -555,6 +555,9 @@ $.extend($.validator, {
 			if ( type === "radio" || type === "checkbox" ) {
 				return $("input[name='" + $element.attr("name") + "']:checked").val();
 			}
+			else if ( type === "number" && typeof element.validity !== "undefined" ) {
+				return !element.validity.badInput ? $(element).val() : false;
+			}
 
 			val = $element.val();
 			if ( typeof val === "string" ) {

--- a/test/number.html
+++ b/test/number.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>Test for jQuery validate() plugin</title>
+
+<script src="jquery.js" type="text/javascript"></script>
+<script src="../dist/jquery.validate.js"></script>
+
+<script type="text/javascript">
+$(document).ready(function() {
+	$('#numberForm').validate();
+});
+</script>
+
+<style type="text/css">
+#numberForm { width: 500px; }
+#numberForm label { width: 250px; display: block; float: left; }
+#numberForm label.error, #commentForm input.submit { margin-left: 253px; }
+#numberForm label.error { background-color: red; }
+</style>
+
+</head>
+<body>
+<form class="cmxform" id="numberForm" method="get" action="">
+	<fieldset>
+		<legend>A simple comment form with submit validation and default messages</legend>
+		<p>
+			<label for="Digits">Number with digits</label>
+			<input id="NumberDigits" name="NumberDigits" class="digits" type="number" />
+		</p>
+		
+		<p>
+			<label for="Digits">Number with number</label>
+			<input id="NumberNumber" name="NumberNumber" class="number" type="number" />
+		</p>
+		
+		<p>
+			<input class="submit" type="submit" value="Submit"/>
+		</p>
+	</fieldset>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
This fixes the issues with having a type="number" and using the class of digits and number. Thanks to @alfonsomartinde for realizing the type="number" goes to blank. Upon further review, the spec also now contains a ValidityState http://www.whatwg.org/specs/web-apps/current-work/#validitystate

I am using .badInput instead of .valid as when you would exceed the range attribute, the .rangeOverFlow or .rangeUnderFlow would trigger. This way the proper error message gets sent from jQuery-validation of over or under the number. I have tested this on IE9-IE11 and the newest Chrome/Safari/Firefox. 

I included a new test file named number.html as I could not use the test.js that was created. The reason being is that if you try to go

```
<input type="number" value="abc"/>
```

The input box shows blank and there are no values and the validity shows that it is valid. 
