### PR TITLE
use `element.name` and `element.type`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -550,10 +550,10 @@ $.extend($.validator, {
 		elementValue: function( element ) {
 			var val,
 				$element = $(element),
-				type = $element.attr("type");
+				type = element.type;
 
 			if ( type === "radio" || type === "checkbox" ) {
-				return $("input[name='" + $element.attr("name") + "']:checked").val();
+				return $("input[name='" + element.name + "']:checked").val();
 			}
 
 			val = $element.val();


### PR DESCRIPTION
instead of using the jquery provided methods, we use the native ones instead. we already rely on them in other places, therefore we don't get anything from using jquery methods here.
