### PR TITLE
Fix Undefined Returned from validationTargetFor

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -769,8 +769,9 @@ $.extend($.validator, {
 		                // If there are elements where validation is not ignored, take the first element
 		                // Else, just take the first element (try not to return undefined)
 		                    element = elements.not(this.settings.ignore)[0];
-		                    if (element === undefined)
+		                    if (element === undefined) {
 		                        element = elements[0];
+		                    }
 		                }
 			}
 			return element;


### PR DESCRIPTION
When a checkable element is passed in, the code in validationTargetFor tries to get the first element with the same name where validation is not ignored.  The problem here is that if validation is ignored for all matching elements with the same name, undefined is stored in element and returned.  The fix I have applied, first checks if there are elements matching the name, then tries to take the first element where validation is not ignored.  If that value is undefined, it then just returns the first element that matches the name regardless of whether validation is ignored.
