### PR TITLE
Demo: Fix captcha and marketo demo

### DIFF
--- a/demo/captcha/images/.htaccess
+++ b/demo/captcha/images/.htaccess
@@ -1,1 +1,0 @@
-AddType application/x-httpd-php .jpg

--- a/demo/captcha/images/image.php
+++ b/demo/captcha/images/image.php
@@ -11,8 +11,8 @@ else
 	$str = $_SESSION['captcha_id'];
 
 // Set the content type
-//header('Content-type: image/png');
-header('Cache-control: no-cache');
+header('Content-Type: image/png');
+header('Cache-Control: no-cache');
 
 // Create an image from button.png
 $image = imagecreatefrompng('button.png');
@@ -31,5 +31,3 @@ imagettftext($image, 14, $rotate, 18, 30, $colour, $font, $str);
 
 // Output the image as a png
 imagepng($image);
-
-?>

--- a/demo/captcha/index.php
+++ b/demo/captcha/index.php
@@ -23,7 +23,7 @@ $_SESSION['captcha_id'] = $str;
  <meta name="description" content="An AJAX CAPTCHA script, written in PHP" />
  
  <script type="text/javascript" src="../../lib/jquery.js"></script>
- <script type="text/javascript" src="../../jquery.validate.js"></script>
+ <script type="text/javascript" src="../../dist/jquery.validate.js"></script>
  <script type="text/javascript" src="captcha.js"></script>
  
  <link rel="stylesheet" type="text/css" href="style.css" />

--- a/demo/marketo/step2.htm
+++ b/demo/marketo/step2.htm
@@ -6,7 +6,7 @@
 
 <script src="../../lib/jquery.js"></script>
 <script src="../../lib/jquery.mockjax.js"></script>
-<script src="../../jquery.validate.js"></script>
+<script src="../../dist/jquery.validate.js"></script>
 
 <script src="jquery.maskedinput.js"></script>
 <script src="mktSignup.js"></script>


### PR DESCRIPTION
Captcha demo did not link to the correct folder for jquery-validate.js, and also had an unnecessary .htaccess allowing execution of jpg files as php (which is needless since there are no jpg in that folder). This is a very minor security risk, but probably not one that needs to be kept around.

Fixed content type of image being incorrectly reported as text/html, which caused browser warnings.

Marketo demo also had a broken link to jquery-validate.js
