### PR TITLE
Return a number when the input is of type number.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -549,6 +549,7 @@ $.extend($.validator, {
 
 		elementValue: function( element ) {
 			var val,
+			    numberVal,
 				$element = $(element),
 				type = element.type;
 
@@ -560,7 +561,7 @@ $.extend($.validator, {
 			    }
 
 			    val = $element.val();
-			    var numberVal = Number(val);
+			    numberVal = Number(val);
 			    return !isNaN(numberVal) ? numberVal : val;
 			}
 


### PR DESCRIPTION
I had an issue when using the spinner from jQuery UI and trying to use the validations. I would compare a string to a number. I made this change and it fixed my issue, but I might be missing something.
