### PR TITLE
New Method: postalCodeCA

### DIFF
--- a/src/additional/postalCodeCA.js
+++ b/src/additional/postalCodeCA.js
@@ -1,0 +1,16 @@
+/**
+ * Matches a valid Canadian Postal Code
+ *
+ * @example jQuery.validator.methods.postalCodeCA( "H0H 0H0", element )
+ * @result true
+ *
+ * @example jQuery.validator.methods.postalCodeCA( "H0H0H0", element )
+ * @result false
+ *
+ * @name jQuery.validator.methods.postalCodeCA
+ * @type Boolean
+ * @cat Plugins/Validate/Methods
+ */
+jQuery.validator.addMethod( "postalCodeCA", function( value, element ) {
+	return this.optional( element ) || /^[ABCEGHJKLMNPRSTVXY]\d[A-Z] \d[A-Z]\d$/.test( value );
+}, "Please specify a valid postal code" );

--- a/src/localization/messages_fr.js
+++ b/src/localization/messages_fr.js
@@ -45,6 +45,7 @@
 		require_from_group: "Veuillez fournir au moins {0} de ces champs.",
 		nifES: "Veuillez fournir un numéro NIF valide.",
 		nieES: "Veuillez fournir un numéro NIE valide.",
-		cifES: "Veuillez fournir un numéro CIF valide."
+		cifES: "Veuillez fournir un numéro CIF valide.",
+		postalCodeCA: "Veuillez fournir un code postal valide.",
 	});
 }(jQuery));

--- a/test/methods.js
+++ b/test/methods.js
@@ -1205,4 +1205,14 @@ test("currency", function() { // Works with any symbol
 	ok(!method( "9.99,9", "£"), "Invalid currency" );
 });
 
+test("postalCodeCA", function() {
+	var method = methodTest("postalCodeCA");
+	ok( method( "H0H 0H0"), "Valid CA Postal Code; Single space" );
+	ok( !method( "H0H0H0"), "Inalid CA Postal Code; No space" );
+	ok( !method( "H0H-0H0"), "Invalid CA Postal Code; Single dash" );
+	ok( !method( "H0H 0H"), "Invalid CA Postal Code; Too Short" );
+	ok( !method( "Z0H 0H"), "Invalid CA Postal Code; Only 'ABCEGHJKLMNPRSTVXY' are valid starting characters" );
+	ok( !method( "h0h 0h0"), "Invalid CA Postal Code; Only upper case characters" );
+});
+
 })(jQuery);


### PR DESCRIPTION
Checks for Canadian postal codes using the base regex from
http://geekswithblogs.net/MainaD/archive/2007/12/03/117321.aspx with
additional constraints from
http://www.canadapost.ca/tools/pg/manual/PGaddress-e.asp.
- First character must be a valid forward station character
- Must be all caps
- Must use space for forth character
