### PR TITLE
for required input text, verify it doesn't match placeholder

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// check for a value, and that it doesn't match the placeholder
-			return $.trim( value ).length > 0 && $.trim(value) !== $( element ).attr( 'placeholder' );
+			return $.trim( value ).length > 0 && $.trim(value) !== $( element ).attr( "placeholder" );
 		},
 
 		// http://jqueryvalidation.org/email-method/


### PR DESCRIPTION
Seems like if a user hops over an input by focusing and defocusing, form submits with the placeholder as the value

Added this check to also make sure the input isn't the placeholder (meaning it's still actually empty)
