### PR TITLE
Default language pack

### DIFF
--- a/src/localization/messages_en.js
+++ b/src/localization/messages_en.js
@@ -3,7 +3,7 @@
  * Locale: EN
  */
 $.extend($.validator.messages, {
-	      required: "This field is required.",
+	required: "This field is required.",
         remote: "Please fix this field.",
         email: "Please enter a valid email address.",
         url: "Please enter a valid URL.",


### PR DESCRIPTION
When we use this plugin with other language, need to check current language. If we have default English language pack, we don't need to check it and this would be nice.

What are you think about this approach?
