### PR TITLE
JSCS config clean-up

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,9 +14,5 @@
 	},
 	"disallowTrailingComma": true,
 	"validateQuoteMarks": "\"",
-	"requireSpacesInsideArrayBrackets": "allButNested",
-	"excludeFiles": [
-		"node_modules/**",
-		"dist/**"
-	]
+	"requireSpacesInsideArrayBrackets": "allButNested"
 }


### PR DESCRIPTION
Removed redundanct settings that already are in jQuery preset from node-jscs.

Ref: https://github.com/mdevils/node-jscs/blob/master/presets/jquery.json

Also removed `excludeFiles` in config for 2 reasons: 
- files should be declared in a single configuration file, Gruntfile.js, even for ignored files
- It's unnecessary to declare those ignored files, they aren't related to the checked files. (Gruntfile and src and test folders).
