### PR TITLE
core: Respect non-error aria-describedby

### DIFF
--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -284,9 +284,29 @@ test( "test existing non-label used as error element", function(assert) {
 	form.validate({ errorElement: "span" });
 
 	ok( !field.valid() );
-	assert.hasError( field );
+	assert.hasError( field, "required" );
 
 	field.val( "foo" );
 	ok( field.valid() );
 	assert.noErrorFor( field );
+});
+
+test( "test existing non-error aria-describedby", function( assert ) {
+	expect( 8 );
+	var form = $( "#testForm17" ),
+		field = $( "#testForm17text" );
+
+	equal( field.attr( "aria-describedby" ), "testForm17text-description" );
+	form.validate({ errorElement: "span" });
+
+	ok( !field.valid() );
+	equal( field.attr( "aria-describedby" ), "testForm17text-description testForm17text-error" );
+	assert.hasError( field, "required" );
+
+	field.val( "foo" );
+	ok( field.valid() );
+	assert.noErrorFor( field );
+
+	strictEqual( "This is where you enter your data", $("#testForm17text-description").text() );
+	strictEqual( "", $("#testForm17text-error").text(), "Error label is empty for valid field" );
 });

--- a/test/index.html
+++ b/test/index.html
@@ -167,6 +167,12 @@
 		<input name="testForm15text" id="testForm15text" data-rule-required="true" data-msg="required" aria-describedby="testForm15text-error" />
 		<span id="testForm15text-error" class="error"></span>
 	</form>
+	<form id="testForm17">
+		<!-- test existing non-error aria-describedby -->
+		<label for="testForm17text">My Label</label>
+		<input name="testForm17text" id="testForm17text" data-rule-required="true" data-msg="required" aria-describedby="testForm17text-description" />
+		<span id="testForm17text-description">This is where you enter your data</span>
+	</form>
 	<form id="dataMessages">
 		<input name="dataMessagesName" id="dataMessagesName" class="required" data-msg-required="You must enter a value here" />
 	</form>

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ QUnit.assert.hasError = function( element, text, message ) {
 // Asserts that there is no visible error for the given element
 QUnit.assert.noErrorFor = function( element, message ) {
 	var errors = $( element ).closest( "form" ).validate().errorsFor( element[ 0 ] ),
-		hidden = ( errors.length === 0 ) || errors.is( ":hidden" ) || ( errors.text() === "" );
+		hidden = ( errors.length === 0 ) || (errors.is( ":hidden" ) && ( errors.text() === "" ));
 	QUnit.push( hidden, hidden, true, message );
 };
 


### PR DESCRIPTION
To follow up from my previous pull request at https://github.com/jzaefferer/jquery-validation/pull/1083 I've improved this solution to better respect existing aria-describedby that do not refer to error labels.

Previously jquery-validate would monopolise this field without regard for aria-describedby references which may point to valid descriptive elements related to the source field (such as captions, right titles, or so on).

It was pretty trivial to reduce the scope of errorsFor to select only error elements, and update showLabel to merge new error IDs with the existing aria-describedby rather than replacing it.
