### PR TITLE
Build: Update jscs, remove rules now included in the jquery preset

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -12,11 +12,6 @@
 	"requireSpacesInAnonymousFunctionExpression": {
 		"beforeOpeningCurlyBrace": true
 	},
-	"disallowTrailingComma": true,
-	"requireMultipleVarDecl": "onevar",
-	"disallowTrailingWhitespace": true,
-	"validateQuoteMarks": "\"",
-	"requireSpacesInsideArrayBrackets": "allButNested",
 	"excludeFiles": [
 		"node_modules/**",
 		"dist/**"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -158,15 +158,7 @@ grunt.initConfig({
 		}
 	},
 	jscs: {
-		core: {
-			src: "<%= jshint.core.src %>"
-		},
-		test: {
-			src: "<%= jshint.test.src %>"
-		},
-		grunt: {
-			src: "<%= jshint.grunt.src %>"
-		}
+		all: [ "<%= jshint.core.src %>", "<%= jshint.test.src %>", "<%= jshint.grunt.src %>" ]
 	},
 	copy: {
 		dist: {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"grunt-contrib-qunit": "0.4.0",
 		"grunt-contrib-uglify": "0.4.0",
 		"grunt-contrib-watch": "0.6.0",
-		"grunt-jscs-checker": "^0.4.4",
+		"grunt-jscs": "^0.6.1",
 		"grunt-text-replace": "0.3.11"
 	},
 	"keywords": [


### PR DESCRIPTION
This is a work in progress. The preset now contains quite a lot more rules so there are a bunch of failures. The line length validation may need to be turned off completely.

I was hoping to do this update "real quick", but that didn't work out. Leaving this here until I can get back to it, hoping someone can help out.

I'm also reporting the rules that we still add on top of the preset that aren't included there, in https://github.com/mdevils/node-jscs/issues/452
