### PR TITLE
Patch used to support "dot" in aria-describedby

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -805,7 +805,7 @@ $.extend( $.validator, {
 				selector = "label[for='" + name + "'], label[for='" + name + "'] *";
 			// aria-describedby should directly reference the error element
 			if ( describer ) {
-				selector = selector + ", #" + describer.replace( /\s+/g, ", #" );
+				selector = selector + ", #" + describer.replace(/\./g, "\\.").replace( /\s+/g, ", #" );
 			}
 			return this
 				.errors()


### PR DESCRIPTION
The errorsFor method does not support the "dots" in id.
With this patch all the dots in "id" will be escaped for the use with "aria-labelledby" selector.
