### PR TITLE
Fix HTML5 Pattern method

### DIFF
--- a/src/additional/pattern.js
+++ b/src/additional/pattern.js
@@ -16,7 +16,7 @@ $.validator.addMethod("pattern", function(value, element, param) {
 		return true;
 	}
 	if (typeof param === "string") {
-		param = new RegExp(param);
+		param = new RegExp("^(?:" + param + ")$");
 	}
 	return param.test(value);
 }, "Invalid format.");

--- a/test/methods.js
+++ b/test/methods.js
@@ -918,6 +918,13 @@ test("pattern", function() {
 	ok( method( "AR1004", "AR\\d{4}" ), "Correct format for the given RegExp" );
 	ok( method( "AR1004", /^AR\d{4}$/ ), "Correct format for the given RegExp" );
 	ok(!method( "BR1004", /^AR\d{4}$/ ), "Invalid format for the given RegExp" );
+	ok( method( "1ABC", "[0-9][A-Z]{3}" ), "Correct format for the given RegExp" );
+	ok(!method( "ABC", "[0-9][A-Z]{3}" ), "Invalid format for the given RegExp" );
+	ok(!method( "1ABC DEF", "[0-9][A-Z]{3}" ), "Invalid format for the given RegExp" );
+	ok( method( "1ABCdef", "[a-zA-Z0-9]+" ), "Correct format for the given RegExp" );
+	ok(!method( "1ABC def", "[a-zA-Z0-9]+" ), "Invalid format for the given RegExp" );
+	ok( method( "2014-10-02", "[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])" ), "Correct format for the given RegExp" );
+	ok(!method( "02-10-2014", "[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])" ), "Invalid format for the given RegExp" );
 });
 
 function testCardTypeByNumber(number, cardname, expected) {


### PR DESCRIPTION
It seems this commit: https://github.com/jzaefferer/jquery-validation/commit/37992c1c9e2e0be8b315ccccc2acb74863439d3e broke html5 input pattern validation.

The pattern should match the entire value of the input, not just a subset.

Using the example from http://www.w3.org/TR/html5/forms.html#the-pattern-attribute on the latest Chrome (35), the input attribute is: `pattern="[0-9][A-Z]{3}"` stated as "A part number is a digit followed by three uppercase letters".

Using native Chrome validation:
'1ABC': valid
'1ABC sdf': invalid

Using `RegExp('^(?:' + param + ')$')`
'1ABC': valid
'1ABC sdf': invalid

Using `RegExp(param)`:
'1ABC': valid
'1ABC sdf': valid (because the first part matches)

This make a lot of patterns useless, for example alpa-numeric patterns which don't allow spaces, but they will match on a single letter as valid, ignoring the rest..

Other libraries do this also like before: https://github.com/dilvie/h5Validate/blob/master/jquery.h5validate.js#L239-L241
