### PR TITLE
Fix core.js for IE 8 support

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -990,7 +990,7 @@ $.extend( $.validator, {
 
 	staticRules: function( element ) {
 		var rules = {},
-			validator = $.data( element.form, "validator" );
+			validator = $.extend(true, {settings: {rules: {}}}, $.data( element.form, "validator" ));
 
 		if ( validator.settings.rules ) {
 			rules = $.validator.normalizeRule( validator.settings.rules[ element.name ] ) || {};


### PR DESCRIPTION
var validator was undefined on IE 8
