### PR TITLE
Core: Fix incorrect email validation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1110,7 +1110,7 @@ $.extend( $.validator, {
 			// Retrieved 2014-01-14
 			// If you have a problem with this implementation, report a bug against the above spec
 			// Or use custom methods to implement your own email validation
-			return this.optional( element ) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test( value );
+			return this.optional( element ) || /^([^@]+?)@(([a-z0-9]-*)*[a-z0-9]+\.)+([a-z0-9]+)$/i.test( value );
 		},
 
 		// http://jqueryvalidation.org/url-method/


### PR DESCRIPTION
Hello jzaefferer how are you? 
I changed the line 1113 in core.js: "return this.optional(element) || /^[a-zA-Z0-9.!#$%&'_+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)_$/.test( value); "to this one: "return this.optional(element) || / ^ (? [^ @] +) @ (. ([a-z0-9] - *) \* [a-z0-9] + ) + ([a-z0-9] +) $ / i.test (value); ", which in addition get a little validation failure that was before, when placed, an email for example: "exemple@exemple" without ".com" or other final address of the mail server, is also smaller than the old, and now if you do not put the end of your email it will not be validated, well i hope had helped out everybody, see ya! :)
