### PR TITLE
Core: Update .bind and .submit to .on and .trigger. Fixes #1254

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1216,7 +1216,7 @@ $.extend( $.validator, {
 			// TODO find a way to bind the event just once, avoiding the unbind-rebind overhead
 			var target = $( param );
 			if ( this.settings.onfocusout ) {
-				target.unbind( ".validate-equalTo" ).on( "blur.validate-equalTo", function() {
+				target.off( ".validate-equalTo" ).on( "blur.validate-equalTo", function() {
 					$( element ).valid();
 				});
 			}


### PR DESCRIPTION
I have updated the instances of .submit to .on("submit") and .trigger("submit") to support people using custom build of jQuery that remove the event aliases
