### PR TITLE
Allow focusout event for hidden elements

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -351,7 +351,7 @@ $.extend( $.validator, {
 					"[type='number'], [type='search'] ,[type='tel'], [type='url'], " +
 					"[type='email'], [type='datetime'], [type='date'], [type='month'], " +
 					"[type='week'], [type='time'], [type='datetime-local'], " +
-					"[type='range'], [type='color'], [type='radio'], [type='checkbox']",
+					"[type='range'], [type='color'], [type='radio'], [type='checkbox'], [type='hidden']",
 					"focusin focusout keyup", delegate)
 				// Support: Chrome, oldIE
 				// "select" is provided as event.target when clicking a option


### PR DESCRIPTION
Allow focusout event for hidden elements. If you have a custom styled form element (ie a dropdown with ul/li structure and a hidden element for the value), and you want to apply form errors on blur, calling blur on the hidden element doesn't work. This fix will allow a blur event on a hidden element.
