### PR TITLE
Fix issue with id's that contain periods . colons : and brackets [ ]

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -766,7 +766,7 @@ $.extend( $.validator, {
 					// If the element is not a child of an associated label, then it's necessary
 					// to explicitly apply aria-describedby
 
-					errorID = error.attr( "id" );
+					errorID = error.attr( "id" ).replace( /(:|\.|\[|\])/g, "\\$1");
 					// Respect existing non-error aria-describedby
 					if ( !describedBy ) {
 						describedBy = errorID;


### PR DESCRIPTION
Fixes #1269 

Alternatively line 824 and 789 could get the regex instead as mentioned in the issue.  This is the simplest way, it will store the escaped id within the aria-description.

( I don't know why I put # 45 in the original commit msg :/ )
