### PR TITLE
autoCreateRanges with Zero-Values

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1057,12 +1057,12 @@ $.extend( $.validator, {
 
 		if ( $.validator.autoCreateRanges ) {
 			// auto-create ranges
-			if ( typeof(rules.min) !== 'undefined' && typeof(rules.max) !== 'undefined' ) {
+			if ( typeof(rules.min) !== "undefined" && typeof(rules.max) !== "undefined" ) {
 				rules.range = [ rules.min, rules.max ];
 				delete rules.min;
 				delete rules.max;
 			}
-			if ( typeof(rules.minlength) !== 'undefined' && typeof(rules.maxlength) !== 'undefined' ) {
+			if ( typeof(rules.minlength) !== "undefined" && typeof(rules.maxlength) !== "undefined" ) {
 				rules.rangelength = [ rules.minlength, rules.maxlength ];
 				delete rules.minlength;
 				delete rules.maxlength;


### PR DESCRIPTION
Automatic creation of range rules doesnt work with zero-values, e.g. min="0" max="150". Checking for type avoids that.
