### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For more information on how to setup a rules and customizations, [check the docu
 
 ## Reporting an Issue
 
-**IMPORTANT NOTE ABOUT EMAIL VALIDATION**. As of version 1.12.0 this plugin is using the same regular expression that the [HTML5 specification suggests for browsers to use](http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#e-mail-state-%28type=email%29). We will follow their lead and use the same check. If you think the specification is wrong, please report the issue to them.
+**IMPORTANT NOTE ABOUT EMAIL VALIDATION**. As of version 1.12.0 this plugin is using the same regular expression that the [HTML5 specification suggests for browsers to use](http://www.w3.org/TR/html5/forms.html#e-mail-state-(type=email)). We will follow their lead and use the same check. If you think the specification is wrong, please report the issue to them.
 
 1. Make sure the problem you're addressing is reproducible.
 2. Use http://jsbin.com or http://jsfiddle.net to provide a test page.


### PR DESCRIPTION
The link to the description of the email validation in the HTML5 spec is broken. Looking at the link in the wayback machine (http://web.archive.org/web/20141020123432/https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email)) it looks like it previously redirected to a page similar to the one I've suggested.

Fixes #1304
