### PR TITLE
Update core.js : Updating Email Regular expression

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1118,7 +1118,7 @@ $.extend( $.validator, {
 			// Retrieved 2014-01-14
 			// If you have a problem with this implementation, report a bug against the above spec
 			// Or use custom methods to implement your own email validation
-			return this.optional( element ) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test( value );
+			return this.optional( element ) || /^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z]{2,4}$/.test( value );
 		},
 
 		// http://jqueryvalidation.org/url-method/


### PR DESCRIPTION
Previous regular expression for email allows this email as valid email address : "user@example"

Current regular expression for email allows this email as valid email address : "user@example.com"

The previous email example tested on this url : http://jqueryvalidation.org/email-method

Please update the example with updated regular expression.
