### PR TITLE
Fix for #1331

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -770,7 +770,7 @@ $.extend( $.validator, {
 					// If the element is not a child of an associated label, then it's necessary
 					// to explicitly apply aria-describedby
 
-					errorID = error.attr( "id" ).replace( /(:|\.|\[|\])/g, "\\$1");
+					errorID = error.attr( "id" ).replace( /(:|\.|\[|\]|\$)/g, "\\$1");
 					// Respect existing non-error aria-describedby
 					if ( !describedBy ) {
 						describedBy = errorID;

--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -344,3 +344,16 @@ test( "test id/name containing brackets", function( assert ) {
 	field.valid();
 	assert.hasError( field, "required" );
 });
+
+test( "test id/name containing $", function( assert ) {
+	var form = $( "#testForm19" ),
+		field = $( "#testForm19\\$text" );
+
+	form.validate({
+		errorElement: "span"
+	});
+
+	form.valid();
+	field.valid();// with bug present fails with "Syntax error, recognized expression..."
+	assert.hasError( field, "required" );
+});

--- a/test/index.html
+++ b/test/index.html
@@ -177,6 +177,10 @@
 		<!-- test id/name containing brackets -->
 		<input name="testForm18[text]" id="testForm18[text]" required>
 	</form>
+	<form id="testForm19">
+	<!-- test id/name containing $ -->
+	<input name="testForm19$text" id="testForm19$text" required>
+	</form>
 	<form id="dataMessages">
 		<input name="dataMessagesName" id="dataMessagesName" class="required" data-msg-required="You must enter a value here">
 	</form>


### PR DESCRIPTION
Fix non label error elements containing $ character in the name/id
(asp.net web forms) causing syntax error in sizzlejs.
