### PR TITLE
stopRequest() doesn't pass on the submit button value

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -25,9 +25,9 @@ $.extend( $.fn, {
 		if ( validator.settings.onsubmit ) {
 
 			this.on( "click.validate", ":submit", function( event ) {
-				if ( validator.settings.submitHandler ) {
-					validator.submitButton = event.target;
-				}
+				// Track the used submit button to properly handle scripted
+				// submits later.
+				validator.submitButton = event.target;
 
 				// allow suppressing validation by adding a cancel class to the submit button
 				if ( $( this ).hasClass( "cancel" ) ) {
@@ -925,7 +925,20 @@ $.extend( $.validator, {
 			}
 			delete this.pending[ element.name ];
 			if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() ) {
+				var hidden;
+				// If no submit handler is set but a submit button is present
+				// ensure the following scripted submit has the value of the
+				// submit button by injecting a hidden field.
+				if ( !this.settings.submitHandler && this.submitButton ) {
+					hidden = $("<input type='hidden'/>")
+					  .attr("name", this.submitButton.name)
+					  .val($(this.submitButton).val())
+					  .appendTo(this.currentForm);
+				}
 				$( this.currentForm ).submit();
+				if ( hidden ) {
+				  hidden.remove();
+				}
 				this.formSubmitted = false;
 			} else if ( !valid && this.pendingRequest === 0 && this.formSubmitted ) {
 				$( this.currentForm ).triggerHandler( "invalid-form", [ this ] );


### PR DESCRIPTION
The `stopRequest()` method currently doesn't properly handle cases in which the form was submitted (`validator.formSubmitted`) but no special submit handler (`validator.settings.submitHandler`) is defined.
The method triggers a submit if the form is valid, but as this is a scripted submit the value of the initially used submit button is missing.
If a submit handler is used the submit button is tracked and then injected as hidden field in `function handle() {`.

I propose we always track the submit button - no matter if `validator.settings.submitHandler`  is defined or not - and if `validator.settings.submitHandler` isn't used `stopRequest()` does its own handling of the submit button value.
Having `validator.submitButton` always set might be an API change - however as of now the library itself only uses the value if `validator.settings.submitHandler` is set too. Which means there should be no change in behavior despite always setting `validator.submitButton`.
