### PR TITLE
Core: Moves some element to settings to have users options when ignoring

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -248,7 +248,7 @@ $.extend( $.validator, {
 		errorContainer: $( [] ),
 		errorLabelContainer: $( [] ),
 		onsubmit: true,
-		ignore: ":hidden",
+		ignore: ":hidden, :submit, :reset, :image, :disabled",
 		ignoreTitle: false,
 		onfocusin: function( element ) {
 			this.lastActive = element;
@@ -585,7 +585,6 @@ $.extend( $.validator, {
 			// Select all valid inputs inside the form (no submit or reset buttons)
 			return $( this.currentForm )
 			.find( "input, select, textarea, [contenteditable]" )
-			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
 				var name = this.name || $( this ).attr( "name" ); // For contenteditable

--- a/src/core.js
+++ b/src/core.js
@@ -248,7 +248,7 @@ $.extend( $.validator, {
 		errorContainer: $( [] ),
 		errorLabelContainer: $( [] ),
 		onsubmit: true,
-		ignore: ":hidden, :submit, :reset, :image, :disabled",
+		ignore: ":hidden, :disabled",
 		ignoreTitle: false,
 		onfocusin: function( element ) {
 			this.lastActive = element;
@@ -585,6 +585,7 @@ $.extend( $.validator, {
 			// Select all valid inputs inside the form (no submit or reset buttons)
 			return $( this.currentForm )
 			.find( "input, select, textarea, [contenteditable]" )
+            .not( ":submit, :reset, :image" )
 			.not( this.settings.ignore )
 			.filter( function() {
 				var name = this.name || $( this ).attr( "name" ); // For contenteditable


### PR DESCRIPTION
Fixes #1691

I see from line 604-607 in jquery.validate.js that it's not including ignore settings. Also it's not including disabled, submit, reset, image as hard coded.
    return $( this.currentForm )
    .find( "input, select, textarea, [contenteditable]" )
    .not( ":submit, :reset, :image, :disabled" )
    .not( this.settings.ignore )

 If the user needs to include hidden fields, they can just put blank in the ignore settings like $("#signupForm").validate({ ignore : "" }); which is good. But I ran into some use cases that I'd like to validate disabled text fields. The only way to do that is to change the core which is a bad practice. 

 The changes proposed that we should treat :submit, :reset, :image, :disabled as settings.ignore. If the user needs to include disabled, they can just pass that as a parameter similar to hidden fields.
