### PR TITLE
remove "required"-attribute from element when removing "required"-rule

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -174,6 +174,7 @@ $.extend( $.fn, {
 			delete data.required;
 			data = $.extend( { required: param }, data );
 			$( element ).attr( "aria-required", "true" );
+			$( element ).attr( "required", "true" );
 		}
 
 		// Make sure remote is at back

--- a/src/core.js
+++ b/src/core.js
@@ -409,6 +409,10 @@ $.extend( $.validator, {
 			// Add aria-required to any Static/Data/Class required fields before first validation
 			// Screen readers require this attribute to be present before the initial submission http://www.w3.org/TR/WCAG-TECHS/ARIA2.html
 			$( this.currentForm ).find( "[required], [data-rule-required], .required" ).attr( "aria-required", "true" );
+			
+			// Add required to any Static/Data/Class required fields before first validation
+			// Required is the html-equivalent to aria-required https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
+			$( this.currentForm ).find( "[aria-required], [data-rule-required], .required" ).attr( "required", "true" );
 		},
 
 		// http://jqueryvalidation.org/Validator.form/

--- a/src/core.js
+++ b/src/core.js
@@ -409,7 +409,7 @@ $.extend( $.validator, {
 			// Add aria-required to any Static/Data/Class required fields before first validation
 			// Screen readers require this attribute to be present before the initial submission http://www.w3.org/TR/WCAG-TECHS/ARIA2.html
 			$( this.currentForm ).find( "[required], [data-rule-required], .required" ).attr( "aria-required", "true" );
-			
+
 			// Add required to any Static/Data/Class required fields before first validation
 			// Required is the html-equivalent to aria-required https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute
 			$( this.currentForm ).find( "[aria-required], [data-rule-required], .required" ).attr( "required", "true" );

--- a/src/core.js
+++ b/src/core.js
@@ -152,6 +152,7 @@ $.extend( $.fn, {
 					delete existingRules[ method ];
 					if ( method === "required" ) {
 						$( element ).removeAttr( "aria-required" );
+						$( element ).removeAttr( "required" );
 					}
 				} );
 				return filtered;


### PR DESCRIPTION
Since the "attributeRules"-method checks for the "required"-attribute of the element, this attribute has to be removed when removing the "required"-rule.

This addresses #1745.
