### PR TITLE
Select Trigger: trigger onkeyup on select input change

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -311,17 +311,9 @@ $.extend( $.validator, {
 		},
 		onchange: function( element, event ) {
 
-			// If target element is a select, trigger focusout on change
+			// If target element is a select, trigger keyup on change
 			if ( element.tagName.toLowerCase() === "select" ) {
-				var _this = element;
-
-				if ( !_this.form && _this.hasAttribute( "contenteditable" ) ) {
-					_this.form = $( _this ).closest( "form" )[ 0 ];
-				}
-
-				var validator = $.data( _this.form, "validator" ),
-					settings = validator.settings;
-				settings.onkeyup.call( validator, _this, event );
+				this.settings.onkeyup.call( this, element, event );
 			}
 		},
 		highlight: function( element, errorClass, validClass ) {

--- a/src/core.js
+++ b/src/core.js
@@ -309,6 +309,21 @@ $.extend( $.validator, {
 				this.element( element.parentNode );
 			}
 		},
+		onchange: function( element, event ) {
+
+			// If target element is a select, trigger focusout on change
+			if ( element.tagName.toLowerCase() === "select" ) {
+				var _this = element;
+
+				if ( !_this.form && _this.hasAttribute( "contenteditable" ) ) {
+					_this.form = $( _this ).closest( "form" )[ 0 ];
+				}
+
+				var validator = $.data( _this.form, "validator" ),
+					settings = validator.settings;
+				settings.onkeyup.call( validator, _this, event );
+			}
+		},
 		highlight: function( element, errorClass, validClass ) {
 			if ( element.type === "radio" ) {
 				this.findByName( element.name ).addClass( errorClass ).removeClass( validClass );
@@ -395,7 +410,7 @@ $.extend( $.validator, {
 			}
 
 			$( this.currentForm )
-				.on( "focusin.validate focusout.validate keyup.validate",
+				.on( "focusin.validate focusout.validate change.validate keyup.validate",
 					":text, [type='password'], [type='file'], select, textarea, [type='number'], [type='search'], " +
 					"[type='tel'], [type='url'], [type='email'], [type='datetime'], [type='date'], [type='month'], " +
 					"[type='week'], [type='time'], [type='datetime-local'], [type='range'], [type='color'], " +


### PR DESCRIPTION
Select elements don't really fit the flow of the keyup events on input elements, making it a bit confusing as text inputs directly update with user input, but the selects are not after selection, but until the 2nd action occurs with the focus out.

To provide similar feedback, this triggers the onkeyup method when a "change" event fires only on a select element, passing along the same event and element details to the call.

Previous validation: https://jsfiddle.net/6ymhsae8/1/
1. Hit submit
2. Start typing in text input, form is valid after first keyup
3. Select an option in the select input, user has to focus out of the input to trigger a revalidation

Updated validation: https://jsfiddle.net/x5qk0n9s/1/
1. Hit submit
2. Start typing in text input, form is valid after first keyup
3. Select an option in the select input, upon selecting a valid option, field is no longer marked as invalid
