### PR TITLE
PhonePK

### DIFF
--- a/src/additional/PhonePK
+++ b/src/additional/PhonePK
@@ -1,0 +1,7 @@
+/*
+Pakistan phone number having atleast 11 number( 03 must be inculuded at the start of every number)
+*/
+/**
+$.validator.addMethod( "phonePK", function( value, element ) {
+	return this.optional( element ) || /^((\+|00(\s|\s?\-\s?)?)03(\s|\s?\-\s?)?(\(0\)[\-\s]?)?|0)[1-9]((\s|\s?\-\s?)?[0-9]){9}$/.test( value );
+}, "Invalid phone number! Please insert in fllowing format 03XX-XXXXXXX" );


### PR DESCRIPTION
This is additional J Query Validate method for Pakistani Cellular phone number not for landline number. it take 12 characters in following format 03XX-XXXXXXX. and you must add 03 at the beginning.
