### PR TITLE
Polish tax id validation method

### DIFF
--- a/src/additional/nipPL.js
+++ b/src/additional/nipPL.js
@@ -1,0 +1,22 @@
+/*
+ * Numer identyfikacji podatkowej ( NIP ) is the way tax identification used in Poland for companies
+ */
+$.validator.addMethod( "nipPL", function( value ) {
+	"use strict";
+
+	value = value.replace( /[^0-9]/g, "" );
+
+	if ( value.length !== 10 ) {
+		return false;
+	}
+
+	var arrSteps = [ 6, 5, 7, 2, 3, 4, 5, 6, 7 ];
+	var intSum = 0;
+	for ( var i = 0; i < 9; i++ ) {
+		intSum += arrSteps[ i ] * value[ i ];
+	}
+	var int2 = intSum % 11;
+	var intControlNr = ( int2 === 10 ) ? 0 : int2;
+
+	return ( intControlNr === parseInt( value[ 9 ], 10 ) );
+}, "Please specify a valid NIP number." );

--- a/src/localization/messages_pl.js
+++ b/src/localization/messages_pl.js
@@ -14,6 +14,7 @@ $.extend( $.validator.messages, {
 	creditcard: "Proszę o podanie prawidłowej karty kredytowej.",
 	equalTo: "Proszę o podanie tej samej wartości ponownie.",
 	extension: "Proszę o podanie wartości z prawidłowym rozszerzeniem.",
+	nipPL: "Proszę o podanie prawidłowego numeru NIP.",
 	maxlength: $.validator.format( "Proszę o podanie nie więcej niż {0} znaków." ),
 	minlength: $.validator.format( "Proszę o podanie przynajmniej {0} znaków." ),
 	rangelength: $.validator.format( "Proszę o podanie wartości o długości od {0} do {1} znaków." ),

--- a/test/methods.js
+++ b/test/methods.js
@@ -1396,6 +1396,34 @@ QUnit.test( "cifES", function( assert ) {
 	assert.ok( !method( "B-43.522.192" ), "CIF invalid: dots and dash" );
 } );
 
+QUnit.test( "nipPL", function( assert ) {
+	var method = methodTest( "nipPL" );
+	assert.ok( method( "3514242002" ), "NIP valid" );
+	assert.ok( method( "8117892840" ), "NIP valid" );
+	assert.ok( method( "7249598309" ), "NIP valid" );
+	assert.ok( method( "6853539166" ), "NIP valid" );
+	assert.ok( method( "5715750580" ), "NIP valid" );
+	assert.ok( method( "3496120813" ), "NIP valid" );
+	assert.ok( method( "1565710251" ), "NIP valid" );
+	assert.ok( method( "8190761165" ), "NIP valid" );
+	assert.ok( method( "9487499667" ), "NIP valid" );
+	assert.ok( method( "9283384684" ), "NIP valid" );
+	assert.ok( method( "3887569138" ), "NIP valid" );
+	assert.ok( method( "3962898856" ), "NIP valid" );
+	assert.ok( !method( "76355753" ), "NIP invalid: too short" );
+	assert.ok( !method( "454" ), "NIP invalid: too short" );
+	assert.ok( !method( "234565545" ), "NIP invalid: too short" );
+	assert.ok( !method( "543455" ), "NIP invalid: too short" );
+	assert.ok( !method( "6345634563456" ), "NIP invalid: too long" );
+	assert.ok( !method( "53453453455335" ), "NIP invalid: too long" );
+	assert.ok( !method( "543453760902" ), "NIP invalid: too long" );
+	assert.ok( !method( "43090012454" ), "NIP invalid: too long" );
+	assert.ok( !method( "3958250194" ), "NIP invalid: wrong checksum" );
+	assert.ok( !method( "3928541049" ), "NIP invalid: wrong checksum" );
+	assert.ok( !method( "5920397295" ), "NIP invalid: wrong checksum" );
+	assert.ok( !method( "9502947712" ), "NIP invalid: wrong checksum" );
+} );
+
 QUnit.test( "maxWords", function( assert ) {
 	var method = methodTest( "maxWords" ),
 		maxWords = 6;


### PR DESCRIPTION
This PR adding new custom method to validate Polish tax identifier number (NIP).

Working example:
https://jsfiddle.net/dycqm91k/1/
