### PR TITLE
Add warning message support for pending remote validations

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -348,6 +348,24 @@ $.extend( $.validator, {
 		min: $.validator.format( "Please enter a value greater than or equal to {0}." ),
 		step: $.validator.format( "Please enter a multiple of {0}." )
 	},
+	warnings: {
+		required: "This field is required.",
+		remote: "Please fix this field.",
+		email: "Please enter a valid email address.",
+		url: "Please enter a valid URL.",
+		date: "Please enter a valid date.",
+		dateISO: "Please enter a valid date (ISO).",
+		number: "Please enter a valid number.",
+		digits: "Please enter only digits.",
+		equalTo: "Please enter the same value again.",
+		maxlength: $.validator.format( "Please enter no more than {0} characters." ),
+		minlength: $.validator.format( "Please enter at least {0} characters." ),
+		rangelength: $.validator.format( "Please enter a value between {0} and {1} characters long." ),
+		range: $.validator.format( "Please enter a value between {0} and {1}." ),
+		max: $.validator.format( "Please enter a value less than or equal to {0}." ),
+		min: $.validator.format( "Please enter a value greater than or equal to {0}." ),
+		step: $.validator.format( "Please enter a multiple of {0}." )
+	},
 
 	autoCreateRanges: false,
 
@@ -749,8 +767,9 @@ $.extend( $.validator, {
 					dependencyMismatch = false;
 
 					if ( result === "pending" ) {
-						this.toHide = this.toHide.not( this.errorsFor( element ) );
-						return;
+						//this.toHide = this.toHide.not( this.errorsFor( element ) );
+						this.formatAndWarning( element, rule );
+						return false;
 					}
 
 					if ( !result ) {
@@ -785,12 +804,20 @@ $.extend( $.validator, {
 				method.substring( 1 ).toLowerCase() ) || $( element ).data( "msg" );
 		},
 
+		customDataWarning: function( element, method ) {
+			return $( element ).data( "warn" + method.charAt( 0 ).toUpperCase() +
+				method.substring( 1 ).toLowerCase() ) || $( element ).data( "warn" );
+		},
+
 		// Return the custom message for the given element name and validation method
 		customMessage: function( name, method ) {
 			var m = this.settings.messages[ name ];
 			return m && ( m.constructor === String ? m : m[ method ] );
 		},
-
+		customWarning: function( name, method ) {
+			var m = this.settings.warnings[ name ];
+			return m && ( m.constructor === String ? m : m[ method ] );
+		},
 		// Return the first defined argument, allowing empty strings
 		findDefined: function() {
 			for ( var i = 0; i < arguments.length; i++ ) {
@@ -834,6 +861,30 @@ $.extend( $.validator, {
 			return message;
 		},
 
+		defaultWarning: function( element, rule ) {
+			if ( typeof rule === "string" ) {
+				rule = { method: rule };
+			}
+
+			var warning = this.findDefined(
+					this.customWarning( element.name, rule.method ),
+					this.customDataWarning( element, rule.method ),
+
+					// 'title' is never undefined, so handle empty string as undefined
+					!this.settings.ignoreTitle && element.title || undefined,
+					$.validator.warnings[ rule.method ],
+					"<strong>Warning: No warning defined for " + element.name + "</strong>"
+				),
+				theregex = /\$?\{(\d+)\}/g;
+			if ( typeof warning === "function" ) {
+				warning = warning.call( this, rule.parameters, element );
+			} else if ( theregex.test( warning ) ) {
+				warning = $.validator.format( warning.replace( theregex, "{$1}" ), rule.parameters );
+			}
+
+			return warning;
+		},
+
 		formatAndAdd: function( element, rule ) {
 			var message = this.defaultMessage( element, rule );
 
@@ -845,6 +896,19 @@ $.extend( $.validator, {
 
 			this.errorMap[ element.name ] = message;
 			this.submitted[ element.name ] = message;
+		},
+
+		formatAndWarning: function( element, rule ) {
+			var warning = this.defaultWarning( element, rule );
+
+			this.errorList.push( {
+				message: warning,
+				element: element,
+				method: rule.method
+			} );
+
+			this.errorMap[ element.name ] = warning;
+			this.submitted[ element.name ] = warning;
 		},
 
 		addWrapper: function( toToggle ) {


### PR DESCRIPTION
Component: Core
Add warning message support for pending remote validations while keeping the field and form as invalid
Fixes #823 #1044 #1045 #1283 #1344 #1465 #1763 #1806

This tweaks will allow you to show a warning message to the user while the async response to the remote validations get resolved and it will make the valid response to be false if the async response to the remote validation is not ready yet but also it will allow to auto clear the invalid state for the field and the form once the async response is ready by using the remote validation normal flow so if the response is valid the field value is valid and the warning message get cleared automatically by jquery validation or if the response is not valid the error message defined is used instead of the warning message.
Just need to add another rule entry for the custom warning messages or the error default messages will be used instead. 
I think that this is the most simply way to solve this problem without having to rewrite the plugin to make it work with deferred/promises. It's a very desirable feature to have deferred/promises support but this will solve the issues and also it could be used for dependency mismatch validations too
