### PR TITLE
Fixed "Cannot read property 'settings'" error

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1230,7 +1230,7 @@ $.extend( $.validator, {
 		var rules = {},
 			validator = $.data( element.form, "validator" );
 
-		if ( validator.settings.rules ) {
+		if ( validator && validator.settings && validator.settings.rules ) {
 			rules = $.validator.normalizeRule( validator.settings.rules[ element.name ] ) || {};
 		}
 		return rules;


### PR DESCRIPTION
First of all, sorry for my horrible english.

I've been facing the problem on a project and searched for work-arounds on the web, but none of them lead to a right solution.

When I try to post a specific form the plugin is returning: "Cannot read property 'settings' of undefined";

Found that the problem was my code, it has a form inside another form. But that's not clear from the message above.
Instead of returning the error, I made a change to check if the property exists on the current form.
'Couse after all, this plug in is not to validate my HTML, it's made to validate my inputs.

Thanks for the awesome plugin.

Some links:
https://github.com/jquery-validation/jquery-validation/issues/1076
https://github.com/jquery-validation/jquery-validation/issues/401
https://github.com/jquery-validation/jquery-validation/issues/917
https://github.com/jquery-validation/jquery-validation/issues/86

https://elnibs.wordpress.com/2013/10/22/jquery-validation-issue-cannot-read-property-settings-of-undefined/
https://forums.asp.net/t/1853275.aspx?+Cannot+read+property+settings+of+undefined+error+when+adding+a+rule+to+validator
