### PR TITLE
Rip747 rasied errors

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -372,6 +372,7 @@ $.extend( $.validator, {
 			this.pending = {};
 			this.invalid = {};
 			this.reset();
+			this.raisedErrors = {};
 
 			var groups = ( this.groups = {} ),
 				rules;
@@ -856,15 +857,24 @@ $.extend( $.validator, {
 
 		formatAndAdd: function( element, rule ) {
 			var message = this.defaultMessage( element, rule );
+			var id = element.id;
+			var method = rule.method;
 
 			this.errorList.push( {
 				message: message,
 				element: element,
-				method: rule.method
+				method: method,
+				id: id
 			} );
-
+			
 			this.errorMap[ element.name ] = message;
 			this.submitted[ element.name ] = message;
+			
+			if(!this.raisedErrors.hasOwnProperty(id)){
+				this.raisedErrors[id] = {};
+			}
+			this.raisedErrors[id][method] = message;
+			
 		},
 
 		addWrapper: function( toToggle ) {

--- a/src/core.js
+++ b/src/core.js
@@ -659,6 +659,7 @@ $.extend( $.validator, {
 			this.errorMap = {};
 			this.toShow = $( [] );
 			this.toHide = $( [] );
+			this.raisedErrors = {};
 		},
 
 		reset: function() {


### PR DESCRIPTION
collect raised error in an object fixes #1925
All errors that are raised will be collected into a raisedErrors object on the base validator object (which can be accessed from an).  The id of the element will be used as the key with an empty object as the value. Each corresponding error with have the method name (such as "required") as the key with the error message as the value.

So for instance... if you have the following rules and messages:

rules: {
    email: { required: true, email: true }
},
messages: {
    email: {required: "Enter your email address", email: "A valid email address is required"}
},

would have a rasiedErrors object of:

this.rasiedErrors["email"]["required"] = "Enter your email address"
this.rasiedErrors["email"]["email"] = "A valid email address is required"