### PR TITLE
Fixed validation for named array within form validation (works for name="xyz" and name="xyz[]") both

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -437,7 +437,7 @@ $.extend( $.validator, {
 		checkForm: function() {
 			this.prepareForm();
 			for ( var i = 0, elements = ( this.currentElements = this.elements() ); elements[ i ]; i++ ) {
-				
+
 				//Fix validation for name array within form
 				if ( this.findByName( elements[ i ].name ).length !== undefined && this.findByName( elements[ i ].name ).length > 1 ) {
 					for ( var cnt = 0; cnt < this.findByName( elements[ i ].name ).length; cnt++ ) {

--- a/src/core.js
+++ b/src/core.js
@@ -436,8 +436,15 @@ $.extend( $.validator, {
 
 		checkForm: function() {
 			this.prepareForm();
-			for ( var i = 0, elements = ( this.currentElements = this.elements() ); elements[ i ]; i++ ) {
-				this.check( elements[ i ] );
+			for ( var i = 0, elements = (this.currentElements = this.elements()); elements[i]; i++ ) {
+				//Fix validation for name array within form
+				if (this.findByName( elements[i].name ).length != undefined && this.findByName( elements[i].name ).length > 1) {
+					for (var cnt = 0; cnt < this.findByName( elements[i].name ).length; cnt++) {
+						this.check( this.findByName( elements[i].name )[cnt] );
+					}
+				} else {
+					this.check( elements[i] );
+				}
 			}
 			return this.valid();
 		},

--- a/src/core.js
+++ b/src/core.js
@@ -436,14 +436,15 @@ $.extend( $.validator, {
 
 		checkForm: function() {
 			this.prepareForm();
-			for ( var i = 0, elements = (this.currentElements = this.elements()); elements[i]; i++ ) {
+			for ( var i = 0, elements = ( this.currentElements = this.elements() ); elements[ i ]; i++ ) {
+				
 				//Fix validation for name array within form
-				if (this.findByName( elements[i].name ).length != undefined && this.findByName( elements[i].name ).length > 1) {
-					for (var cnt = 0; cnt < this.findByName( elements[i].name ).length; cnt++) {
-						this.check( this.findByName( elements[i].name )[cnt] );
+				if ( this.findByName( elements[ i ].name ).length !== undefined && this.findByName( elements[ i ].name ).length > 1 ) {
+					for ( var cnt = 0; cnt < this.findByName( elements[ i ].name ).length; cnt++ ) {
+						this.check( this.findByName( elements[ i ].name )[ cnt ] );
 					}
 				} else {
-					this.check( elements[i] );
+					this.check( elements[ i ] );
 				}
 			}
 			return this.valid();


### PR DESCRIPTION

#### Description
If a form input has a name="xyz[]" then only first element with name="xyz[]" is validated and rest are ignored.
This fix adds the flexibility for validating the named array (name="xyz[]") or a single name attribute (name="xyz") with no extra effort


Thank you!
