### PR TITLE
Core: Added :and expression

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -197,6 +197,10 @@ $.extend( $.fn, {
 // Custom selectors
 $.extend( $.expr.pseudos || $.expr[ ":" ], {		// '|| $.expr[ ":" ]' here enables backwards compatibility to jQuery 1.7. Can be removed when dropping jQ 1.7.x support
 
+	and: function( a, b, c ) {
+		return $.find( c[ 3 ] ).length !== 0;
+	},
+
 	// https://jqueryvalidation.org/blank-selector/
 	blank: function( a ) {
 		return !$.trim( "" + $( a ).val() );

--- a/test/test.js
+++ b/test/test.js
@@ -1514,6 +1514,15 @@ QUnit.test( "option: subformRequired", function( assert ) {
 
 QUnit.module( "expressions" );
 
+QUnit.test( "expression: :and", function( assert ) {
+	var e = $( "#check1" )[ 0 ];
+	assert.equal( $( e ).filter( ":checked:and(#check1b:checked)" ).length, 0 );
+	$( "#check1b" ).prop( "checked", true );
+	assert.equal( $( e ).filter( ":checked:and(#check1b:checked)" ).length, 1 );
+	e.checked = false;
+	assert.equal( $( e ).filter( ":checked:and(#check1b:checked)" ).length, 0 );
+} );
+
 QUnit.test( "expression: :blank", function( assert ) {
 	var e = $( "#lastname" )[ 0 ];
 	assert.equal( $( e ).filter( ":blank" ).length, 1 );


### PR DESCRIPTION
It's often desirable to require a field only if conditions a _and_ b are fulfilled. This expression lets us do this in a simple manner using a custom expression.

In this case we want `confirm` to be required if the value of `first` is `"John"` or `"Jane"` and the value of `last` is `"Doe"`

```html
<input id="first">
<input id="last">
<input id="confirm" type="checkbox" data-required="#last[value='Doe']:and(#first[value='John'], #first[value='Jane'])" />
```