### PR TITLE
Core: Add sanity checks to dateISO method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1382,8 +1382,37 @@ $.extend( $.validator, {
 		},
 
 		// https://jqueryvalidation.org/dateISO-method/
-		dateISO: function( value, element ) {
-			return this.optional( element ) || /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/.test( value );
+		dateISO: function (value, element) {
+			if (this.optional(element)) {
+				return true;
+			}
+			var check = false,
+				re = /^(\d{4})(?:-){1}(0[1-9]|1[012])(?:-){1}(0[1-9]|[12][0-9]|3[01])$/,
+				adata,
+				yyyy,
+				mm,
+				dd,
+				isLeap;
+			if (re.test(value)) {
+				check = true;
+
+				// Do a sanity check to ensure the date is valid
+				adata = value.match(re);
+				yyyy = parseInt(adata[1], 10);
+				mm = parseInt(adata[2], 10);
+				dd = parseInt(adata[3], 10);
+
+				if ((mm === 4 || mm === 6 || mm === 9 || mm === 11) && dd === 31) {
+					check = false;
+				} else if (mm === 2) {
+					isLeap = (yyyy % 4 === 0 && (yyyy % 100 !== 0 || yyyy % 400 === 0));
+
+					if (dd > 29 || (dd === 29 && !isLeap)) {
+						check = false;
+					}
+				}
+			}
+			return check;
 		},
 
 		// https://jqueryvalidation.org/number-method/

--- a/test/methods.js
+++ b/test/methods.js
@@ -192,16 +192,25 @@ QUnit.test( "dateISO", function( assert ) {
 	assert.ok( method( "1990-01-31" ), "Valid date" );
 	assert.ok( method( "1990-12-01" ), "Valid date" );
 	assert.ok( method( "1990-12-31" ), "Valid date" );
-	assert.ok( method( "1990/06/06" ), "Valid date" );
-	assert.ok( method( "1990-6-6" ), "Valid date" );
-	assert.ok( method( "1990/6/6" ), "Valid date" );
+	assert.ok( !method( "1990/06/06" ), "Invalid date" );
+	assert.ok( !method( "1990-6-6" ), "Invalid date" );
+	assert.ok( !method( "1990/6/6" ), "Invalid date" );
 	assert.ok( !method( "1990-106-06" ), "Invalid date" );
+	assert.ok( !method( "1990-06-106" ), "Invalid date" );
 	assert.ok( !method( "190-06-06" ), "Invalid date" );
 	assert.ok( !method( "1990-00-06" ), "Invalid date" );
 	assert.ok( !method( "1990-13-01" ), "Invalid date" );
 	assert.ok( !method( "1990-01-00" ), "Invalid date" );
 	assert.ok( !method( "1990-01-32" ), "Invalid date" );
-	assert.ok( !method( "1990-13-32" ), "Invalid date" );
+	assert.ok( !method( "1990-13-01" ), "Invalid date" );
+	assert.ok( !method( "19990-01-01" ), "Invalid date" );
+	assert.ok( method( "1992-02-29" ), "Valid divide-by-4 leap day" );
+	assert.ok( !method( "1990-02-29" ), "Invalid divide-by-4 leap day" );
+	assert.ok( method( "2000-02-29" ), "Valid end-of-century leap day" );
+	assert.ok( !method( "1900-02-29" ), "Invalid end-of-century leap day" );
+	assert.ok( !method( "2100-02-29" ), "Invalid divide-by-100 leap day" );
+	assert.ok( method( "1990-10-31" ), "Valid last day of month" );
+	assert.ok( !method( "1990-09-31" ), "Invalid last day of month" );
 } );
 
 /* Disabled for now, need to figure out how to test localized methods


### PR DESCRIPTION
Updated regex for dateISO to match the ISO 8601 standard.  Added checks for leap years and for months that only have 30 days.  

This is a redo of PR #1528 due to mangled repo. 

Fixes #1861.

I don't expect it to be committed yet for the reasons outlined in https://github.com/jquery-validation/jquery-validation/pull/1528#issuecomment-150042586.