### PR TITLE
Test: Add missing description to a test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1039,7 +1039,7 @@ QUnit.test( "elementValue() returns the file input's name without the prefix 'C:
 	assert.ok( !v.element( fileInput ), "The fake file input is invalid (length = 12, maxlength = 10)" );
 } );
 
-QUnit.test( "", function( assert ) {
+QUnit.test( "Required rule should not take precedence over number & digits rules", function( assert ) {
 	var v = $( "#userForm" ).validate(),
 
 		// A fake number input


### PR DESCRIPTION
This test was added a year+ ago as part of #1679, but forgot to assign a description to it. Discovered it today while browsing the test files.