### PR TITLE
Setting: Adding ability to override the default element tag list.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -265,6 +265,7 @@ $.extend( $.validator, {
 		errorLabelContainer: $( [] ),
 		onsubmit: true,
 		ignore: ":hidden",
+		inputSelector: "input, select, textarea, [contenteditable]",
 		ignoreTitle: false,
 		onfocusin: function( element ) {
 			this.lastActive = element;
@@ -616,7 +617,7 @@ $.extend( $.validator, {
 
 			// Select all valid inputs inside the form (no submit or reset buttons)
 			return $( this.currentForm )
-			.find( "input, select, textarea, [contenteditable]" )
+			.find( validator.settings.inputSelector )
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {

--- a/test/index.html
+++ b/test/index.html
@@ -445,6 +445,26 @@
 		<br>
 		<input type="text" name="something" id="_something" />
 	</form>
+	<form id="customElements">
+		<input name="text1" required type="text" value="text1Value" />
+		<input name="text2" required type="text" />
+
+		<textarea name="textArea1" required>textArea1Value</textarea>
+		<textarea name="textArea2" required></textarea>
+
+		<select name="select1" required>
+			<option value=""></option>
+			<option value="select1Option1Value" selected>1</option>
+		</select>
+
+		<select name="select2" required>
+			<option value=""></option>
+			<option value="select2Option1Value">1</option>
+		</select>
+
+		<custom-input name="customInput1" required value=""></custom-input>
+		<custom-input name="customInput2" required value="customInput2Value"></custom-input>
+	</form>
 </div>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -2511,3 +2511,61 @@ QUnit.test( "addMethod, reusing remote in custom method", function( assert ) {
 	e.val( "john.doe@gmail.com" );
 	assert.strictEqual( v.element( e ), true, "still invalid, because remote validation must block until it returns; dependency-mismatch considered as valid though" );
 } );
+
+QUnit.test( "inputSelector setting, defaults to native input tags", function( assert ) {
+	var expectedErrorCount = 3;
+	var form = $( "#customElements" );
+
+	var validator = form.validate();
+
+	assert.ok( !validator.form() );
+	assert.strictEqual( validator.numberOfInvalids(), expectedErrorCount );
+
+	validator.destroy();
+} );
+
+QUnit.test( "inputSelector setting, validates custom tags", function( assert ) {
+	var expectedErrorCount = 1;
+	var form = $( "#customElements" );
+	var validator;
+
+	form
+		.find( "custom-input" )
+		.each( function( index, element ) {
+			element.value = $( element ).attr( "value" );
+			element.name = $( element ).attr( "name" );
+			element.form = $( element ).closest( "form" )[ 0 ];
+		} );
+
+	validator = form.validate( {
+		inputSelector: "custom-input"
+	} );
+
+	assert.ok( !validator.form() );
+	assert.strictEqual( validator.numberOfInvalids(), expectedErrorCount );
+
+	validator.destroy();
+} );
+
+QUnit.test( "inputSelector setting, validates input and custom tags", function( assert ) {
+	var expectedErrorCount = 4;
+	var form = $( "#customElements" );
+	var validator;
+
+	form
+		.find( "custom-input" )
+		.each( function( index, element ) {
+			element.value = $( element ).attr( "value" );
+			element.name = $( element ).attr( "name" );
+			element.form = $( element ).closest( "form" )[ 0 ];
+		} );
+
+	validator = form.validate( {
+		inputSelector: "input, textarea, select, custom-input"
+	} );
+
+	assert.ok( !validator.form() );
+	assert.strictEqual( validator.numberOfInvalids(), expectedErrorCount );
+
+	validator.destroy();
+} );


### PR DESCRIPTION
This override allows elements implementing an input interface to be validated

#### Description
We have been using jQuery validation for several years and it has been very useful for our organization. Unfortunately, one area that it falls short is where it doesn't support custom elements that behave like native inputs. There is no way (without overriding methods) that we know of to validate any input type other than those that are hard coded in the `elements()` prototype method. This Pull Request attempts to provide a simple method for customizing what tags the `element()` function looks for.
