### PR TITLE
Localization: Add missing format method.

### DIFF
--- a/src/localization/messages_fr.js
+++ b/src/localization/messages_fr.js
@@ -43,7 +43,7 @@ $.extend( $.validator.messages, {
 	creditcardtypes: "Veuillez fournir un numéro de carte de crédit valide.",
 	ipv4: "Veuillez fournir une adresse IP v4 valide.",
 	ipv6: "Veuillez fournir une adresse IP v6 valide.",
-	require_from_group: "Veuillez fournir au moins {0} de ces champs.",
+	require_from_group: $.validator.format( "Veuillez fournir au moins {0} de ces champs." ),
 	nifES: "Veuillez fournir un numéro NIF valide.",
 	nieES: "Veuillez fournir un numéro NIE valide.",
 	cifES: "Veuillez fournir un numéro CIF valide.",

--- a/src/localization/messages_tr.js
+++ b/src/localization/messages_tr.js
@@ -20,5 +20,5 @@ $.extend( $.validator.messages, {
 	range: $.validator.format( "Lütfen {0} ile {1} arasında bir değer giriniz." ),
 	max: $.validator.format( "Lütfen {0} değerine eşit ya da daha küçük bir değer giriniz." ),
 	min: $.validator.format( "Lütfen {0} değerine eşit ya da daha büyük bir değer giriniz." ),
-	require_from_group: "Lütfen bu alanların en az {0} tanesini doldurunuz."
+	require_from_group: $.validator.format( "Lütfen bu alanların en az {0} tanesini doldurunuz." )
 } );


### PR DESCRIPTION
I searched all localization files for "{0}" to see if I could find any without a call to the `format `method.  Found two.

Partially fixes #2065 (the French part, identified by @HawkonDK).  Danish translations were added in https://github.com/jquery-validation/jquery-validation/pull/2067, so that issue can be closed with this PR.