### PR TITLE
Build: Generate sub-resource integrity hashes of the distribution files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -171,6 +171,27 @@ grunt.initConfig( {
 				}
 			]
 		}
+	},
+
+	// Generate the sub-resource integrity hashes of the distribution files
+	sri: {
+		options: {
+			algorithms: [ "sha256", "sha384", "sha512" ],
+
+			// The target json file
+			dest: "dist/jquery-validation-sri.json",
+
+			// Stringify the JSON output in a pretty format
+			pretty: true
+		},
+
+		all: {
+			src: [
+				"dist/jquery.validate.{min.js,js}",
+				"dist/additional-methods.{min.js,js}",
+				"dist/localization/*.js"
+			]
+		}
 	}
 } );
 
@@ -183,9 +204,10 @@ grunt.loadNpmTasks( "grunt-contrib-watch" );
 grunt.loadNpmTasks( "grunt-jscs" );
 grunt.loadNpmTasks( "grunt-contrib-copy" );
 grunt.loadNpmTasks( "grunt-text-replace" );
+grunt.loadNpmTasks( "grunt-sri" );
 
 grunt.registerTask( "default", [ "concat", "copy", "jscs", "jshint", "qunit" ] );
-grunt.registerTask( "release", [ "default", "uglify", "replace", "compress" ] );
+grunt.registerTask( "release", [ "default", "uglify", "replace", "compress", "sri" ] );
 grunt.registerTask( "start", [ "concat", "watch" ] );
 
 };

--- a/build/release.js
+++ b/build/release.js
@@ -42,7 +42,10 @@ Release.define({
 			"dist/additional-methods.js",
 			"dist/additional-methods.min.js",
 			"dist/jquery.validate.js",
-			"dist/jquery.validate.min.js"
+			"dist/jquery.validate.min.js",
+
+			// The sub-resource integrity hashes of the distribution files
+			"dist/jquery-validation-sri.json"
 		]);
 	},
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"grunt-contrib-uglify": "1.0.1",
 		"grunt-contrib-watch": "1.0.0",
 		"grunt-jscs": "2.8.0",
+		"grunt-sri": "0.2.0",
 		"grunt-text-replace": "0.4.0",
 		"qunitjs": "2.3.3"
 	},


### PR DESCRIPTION
With this, running `grunt release` will generate ~~3 new files~~ 1 file in the `dist` folder:
* ~~`sri-core.json`: contains the hashes of `jquery-validate.js` and `jquery-validate.min.js`~~
* ~~`sri-additional.json`: contains the hashes of `additional-methods.js` and `additional-methods.min.js`~~
* ~~`sri-localization.json`: contains the hashes of all JS files inside `localization` folder~~
* `jquery-validation-sri.json`: contains the hashes of all JS files inside `dist` folder

I can add those files to the list of [distribution files][1] in case we want to commit them to GitHub.

[1]: https://github.com/jquery-validation/jquery-validation/blob/b70fcc20f1bcdcd63422686595a48950326309f1/build/release.js#L40-L46

//c @staabm @vanillajonathan 