### PR TITLE
Additional: max size and number of files

### DIFF
--- a/src/additional/maxfiles.js
+++ b/src/additional/maxfiles.js
@@ -5,10 +5,8 @@ $.validator.addMethod( "maxfiles", function( value, element, param ) {
 	}
 
 	if ( $( element ).attr( "type" ) === "file" ) {
-		if ( element.files && element.files.length ) {
-			if ( element.files.length > param ) {
-				return false;
-			}
+		if ( element.files && element.files.length && element.files.length > param ) {
+			return false;
 		}
 	}
 

--- a/src/additional/maxfiles.js
+++ b/src/additional/maxfiles.js
@@ -5,7 +5,7 @@ $.validator.addMethod( "maxfiles", function( value, element, param ) {
 	}
 
 	if ( $( element ).attr( "type" ) === "file" ) {
-		if ( element.files && element.files.length && element.files.length > param ) {
+		if ( element.files && element.files.length > param ) {
 			return false;
 		}
 	}

--- a/src/additional/maxfiles.js
+++ b/src/additional/maxfiles.js
@@ -1,0 +1,16 @@
+//Limit the number of files in a FileList.
+$.validator.addMethod( "maxfiles", function( value, element, param ) {
+	if ( this.optional( element ) ) {
+		return true;
+	}
+
+	if ( $( element ).attr( "type" ) === "file" ) {
+		if ( element.files && element.files.length ) {
+			if ( element.files.length > param ) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}, $.validator.format( "Please select no more than {0} files." ) );

--- a/src/additional/maxfiles.js
+++ b/src/additional/maxfiles.js
@@ -1,4 +1,4 @@
-//Limit the number of files in a FileList.
+// Limit the number of files in a FileList.
 $.validator.addMethod( "maxfiles", function( value, element, param ) {
 	if ( this.optional( element ) ) {
 		return true;

--- a/src/additional/maxsize.js
+++ b/src/additional/maxsize.js
@@ -1,4 +1,4 @@
-//Limit the size of each individual file in a FileList.
+// Limit the size of each individual file in a FileList.
 $.validator.addMethod( "maxsize", function( value, element, param ) {
 	if ( this.optional( element ) ) {
 		return true;

--- a/src/additional/maxsize.js
+++ b/src/additional/maxsize.js
@@ -1,0 +1,18 @@
+//Limit the size of each individual file in a FileList.
+$.validator.addMethod( "maxsize", function( value, element, param ) {
+	if ( this.optional( element ) ) {
+		return true;
+	}
+
+	if ( $( element ).attr( "type" ) === "file" ) {
+		if ( element.files && element.files.length ) {
+			for ( var i = 0; i < element.files.length; i++ ) {
+				if ( element.files[ i ].size > param ) {
+					return false;
+				}
+			}
+		}
+	}
+
+	return true;
+}, $.validator.format( "File size must not exceed {0} bytes each." ) );

--- a/src/additional/maxsizetotal.js
+++ b/src/additional/maxsizetotal.js
@@ -1,4 +1,4 @@
-//Limit the size of all files in a FileList.
+// Limit the size of all files in a FileList.
 $.validator.addMethod( "maxsizetotal", function( value, element, param ) {
 	if ( this.optional( element ) ) {
 		return true;

--- a/src/additional/maxsizetotal.js
+++ b/src/additional/maxsizetotal.js
@@ -1,0 +1,22 @@
+//Limit the size of all files in a FileList.
+$.validator.addMethod( "maxsizetotal", function( value, element, param ) {
+	if ( this.optional( element ) ) {
+		return true;
+	}
+
+	if ( $( element ).attr( "type" ) === "file" ) {
+		if ( element.files && element.files.length ) {
+			var totalSize = 0;
+
+			for ( var i = 0; i < element.files.length; i++ ) {
+				totalSize += element.files[ i ].size;
+				if ( totalSize > param ) {
+					return false;
+				}
+			}
+		}
+	}
+
+	return true;
+}, $.validator.format( "Total size of all files must not exceed {0} bytes." ) );
+


### PR DESCRIPTION
This is a continuation of abandoned PR https://github.com/jquery-validation/jquery-validation/pull/1512, in that it validates the maximum size of a selected file.

Since the "file" type can contain the multiple attribute, another method was added to validate the maximum size of all selected files.  Finally, a third method was added to validate the maximum number of files.
