### PR TITLE
Additional: allow N11 exchange for non-geo US phone. Fixes #1695

### DIFF
--- a/src/additional/phoneUS.js
+++ b/src/additional/phoneUS.js
@@ -17,5 +17,5 @@
 $.validator.addMethod( "phoneUS", function( phone_number, element ) {
 	phone_number = phone_number.replace( /\s+/g, "" );
 	return this.optional( element ) || phone_number.length > 9 &&
-		phone_number.match( /^(\+?1-?)?(\([2-9]([02-9]\d|1[02-9])\)|[2-9]([02-9]\d|1[02-9]))-?[2-9]([02-9]\d|1[02-9])-?\d{4}$/ );
+		phone_number.match( /^(\+?1-?)?(\([2-9]([02-9]\d|1[02-9])\)|[2-9]([02-9]\d|1[02-9]))-?[2-9]\d{2}-?\d{4}$/ );
 }, "Please specify a valid phone number" );

--- a/test/methods.js
+++ b/test/methods.js
@@ -814,9 +814,9 @@ QUnit.test( "phone (us)", function( assert ) {
 	assert.ok( method( "1(212)-999-2345" ), "Valid US phone number" );
 	assert.ok( method( "212 999 2344" ), "Valid US phone number" );
 	assert.ok( method( "212-999-0983" ), "Valid US phone number" );
+	assert.ok( method( "234-911-5678" ), "Valid US phone number" );
 	assert.ok( !method( "111-123-5434" ), "Invalid US phone number. Area Code cannot start with 1" );
 	assert.ok( !method( "212 123 4567" ), "Invalid US phone number. NXX cannot start with 1" );
-	assert.ok( !method( "234-911-5678" ), "Invalid US phone number, because the exchange code cannot be in the form N11" );
 	assert.ok( !method( "911-333-5678" ), "Invalid US phone number, because the area code cannot be in the form N11" );
 	assert.ok( method( "234-912-5678" ), "Valid US phone number" );
 } );


### PR DESCRIPTION
Adds support to the phoneUS validator for a 1 in the third position of the CO code to support non-geographical US area codes. 

For example:
800-811-xxxx (replacing xxxx with some real 4 digit number) is a valid US phone number but not currently accepted by the validator.
