### PR TITLE
Translation: fix meaning in Bulgarian sentence

### DIFF
--- a/src/localization/messages_bg.js
+++ b/src/localization/messages_bg.js
@@ -14,7 +14,7 @@ $.extend( $.validator.messages, {
 	creditcard: "Моля, въведете валиден номер на кредитна карта.",
 	equalTo: "Моля, въведете същата стойност отново.",
 	extension: "Моля, въведете стойност с валидно разширение.",
-	maxlength: $.validator.format( "Моля, въведете повече от {0} символа." ),
+	maxlength: $.validator.format( "Моля, въведете не повече от {0} символа." ),
 	minlength: $.validator.format( "Моля, въведете поне {0} символа." ),
 	rangelength: $.validator.format( "Моля, въведете стойност с дължина между {0} и {1} символа." ),
 	range: $.validator.format( "Моля, въведете стойност между {0} и {1}." ),


### PR DESCRIPTION
The "maxlength" message has wrong meaning in Bulgarian. The current meaning is:
Please enter more than {0} characters.
The correct meaning should be:
Please enter no more than {0} characters.
I could use "less" (по-малко) to mean the same thing, but it does not sound natural in this context.