### PR TITLE
Build: test on node 6.x and drop node 0.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.12
+  - 6
 
 sudo: false
 


### PR DESCRIPTION
This fixes the flast failed builds