### PR TITLE
Add Accessibility section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ $("#myForm").validate({
 });
 ```
 
+## Accessibility
+For an invalid field, the default output for the jQuery Validation Plugin is an error message in a `<label>` element. This results in two `<label>` elements pointing to a single input field using the `for` attribute. While this is valid HTML, it has inconsistent support across screen readers.
+
+For greater screen reader support in your form's validation, use the `errorElement` parameter in the `validate()` method. This option outputs the error in an element of your choice and automatically adds ARIA attributes to the HTML that help with screen reader support.
+
+`aria-describedby` is added to the input field and it is programmatically tied to the error element chosen in the `errorElement` parameter.
+
+``` js
+$("#myform").validate({
+  errorElement: "span"
+});
+```
+
+``` html
+<label for="name">Name</label>
+<input id="name" aria-describedby="unique-id-here">
+<span class="error" id="unique-id-here">This field is required</span>
+```
+
 ## License
 Copyright &copy; Jörn Zaefferer<br>
 Licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ $("#myform").validate({
 <span class="error" id="unique-id-here">This field is required</span>
 ```
 
+[Learn more about errorElement](https://jqueryvalidation.org/validate/#errorelement)
+
 ## License
 Copyright &copy; Jörn Zaefferer<br>
 Licensed under the MIT license.


### PR DESCRIPTION
Adding Accessibility section to the readme that speaks to using `errorElement` in the `validate()` method.

Thank you!
