### PR TITLE
All: Increase number of days of inactivity of stale issues to 60 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale


### PR DESCRIPTION
Hi @staabm,

This will help us more to not miss some important issues. 30 days is good, but sometimes I want to address an issue and a month pass quickly.

Also, do you think we need to add some labels (e.g `question`) to the list of excluded labels?