### PR TITLE
Updating bug for fields with no Name nor Id

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1025,7 +1025,7 @@ $.extend( $.validator, {
 		// meta-characters that should be escaped in order to be used with JQuery
 		// as a literal part of a name/id or any selector.
 		escapeCssMeta: function( string ) {
-			return string ? string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" ) : '';
+			return string ? string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" ) : "";
 		},
 
 		idOrName: function( element ) {

--- a/src/core.js
+++ b/src/core.js
@@ -1025,7 +1025,7 @@ $.extend( $.validator, {
 		// meta-characters that should be escaped in order to be used with JQuery
 		// as a literal part of a name/id or any selector.
 		escapeCssMeta: function( string ) {
-			return string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
+			return string ? string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" ) : '';
 		},
 
 		idOrName: function( element ) {


### PR DESCRIPTION
When using some WYSIWYG like summernote, by default, contenteditable area has not Id nor Name, in this cases the script generates error in "escapeCssMeta()" when trying to do replace on undefined because the string arg is the result of "idOrName()" on line #1009.

PS : I dont know how the tests work nor how to create one... If you can send me some info about it I could do it.

DEMO ERROR : http://jsfiddle.net/3bpnw7uo/8/