### PR TITLE
Core: Call to resetInternals removed in remote validation callback

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1570,7 +1570,6 @@ $.extend( $.validator, {
 					validator.settings.messages[ element.name ][ method ] = previous.originalMessage;
 					if ( valid ) {
 						submitted = validator.formSubmitted;
-						validator.resetInternals();
 						validator.toHide = validator.errorsFor( element );
 						validator.formSubmitted = submitted;
 						validator.successList.push( element );


### PR DESCRIPTION
Hi,

The modification is related to the following issues, which although marked as closed don't seem to be properly fixed:
https://github.com/jquery-validation/jquery-validation/issues/12
https://github.com/jquery-validation/jquery-validation/issues/1669
https://github.com/jquery-validation/jquery-validation/issues/1375

From the user point of view the issue is that fields in a form which has at least one field with remote validation will be "unhighlighted" if the remotely validated field has a valid default value (remote validation is successful and any other invalid field is cleared out);
Validation error messages are still shown on the interface, but the invalid fields are shown as valid (the CSS class is reset)

Thanks,
Leonardo
