### PR TITLE
Core: change focus() to trigger("focus")

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -602,7 +602,7 @@ $.extend( $.validator, {
 				try {
 					$( this.findLastActive() || this.errorList.length && this.errorList[ 0 ].element || [] )
 					.filter( ":visible" )
-					.focus()
+					.trigger( "focus" )
 
 					// Manually trigger focusin event; without it, focusin handler isn't called, findLastActive won't have anything to find
 					.trigger( "focusin" );


### PR DESCRIPTION
#### Description
This PR changes the focus() to trigger("focus"), so that it is not flagged up in non-live environments using the jQuery Migrate 3.x plugin.

https://github.com/jquery-validation/jquery-validation/issues/2238