### PR TITLE
elementValue fix for editable content

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -703,9 +703,9 @@ $.extend( $.validator, {
 			}
 
 			if ( isContentEditable ) {
-				val = $element.text();
-			} else {
 				val = $element.val();
+			} else {
+				val = $element.text();
 			}
 
 			if ( type === "file" ) {


### PR DESCRIPTION
<input type="text" is editable, so .val() should be used instead of text()