### PR TITLE
Core: Instead of fetching only child of form, fetch all elements & filter records.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -625,8 +625,8 @@ $.extend( $.validator, {
 				rulesCache = {};
 
 			// Select all valid inputs inside the form (no submit or reset buttons)
-			return $( this.currentForm )
-			.find( "input, select, textarea, [contenteditable]" )
+			return $( this.currentForm ).fields()
+			.filter( "input, select, textarea, [contenteditable]" )
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
@@ -664,7 +664,7 @@ $.extend( $.validator, {
 
 		errors: function() {
 			var errorClass = this.settings.errorClass.split( " " ).join( "." );
-			return $( this.settings.errorElement + "." + errorClass, this.errorContext );
+			return $( this.settings.errorElement + "." + errorClass );
 		},
 
 		resetInternals: function() {

--- a/src/core.js
+++ b/src/core.js
@@ -625,8 +625,10 @@ $.extend( $.validator, {
 				rulesCache = {};
 
 			// Select all valid inputs inside the form (no submit or reset buttons)
-			return $( this.currentForm ).fields()
-			.filter( "input, select, textarea, [contenteditable]" )
+			console.error( $.merge( $( this.currentForm ).find( "input, select, textarea, [contenteditable]" ),
+            $( this.currentForm.elements ).filter( "input, select, textarea, [contenteditable]" ) ) );
+			return $.merge( $( this.currentForm ).find( "input, select, textarea, [contenteditable]" ),
+            $( this.currentForm.elements ).filter( "input, select, textarea, [contenteditable]" ) )
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
@@ -664,7 +666,7 @@ $.extend( $.validator, {
 
 		errors: function() {
 			var errorClass = this.settings.errorClass.split( " " ).join( "." );
-			return $( this.settings.errorElement + "." + errorClass );
+			return $( this.settings.errorElement + "." + errorClass, this.errorContext );
 		},
 
 		resetInternals: function() {

--- a/src/core.js
+++ b/src/core.js
@@ -625,8 +625,6 @@ $.extend( $.validator, {
 				rulesCache = {};
 
 			// Select all valid inputs inside the form (no submit or reset buttons)
-			console.error( $.merge( $( this.currentForm ).find( "input, select, textarea, [contenteditable]" ),
-            $( this.currentForm.elements ).filter( "input, select, textarea, [contenteditable]" ) ) );
 			return $.merge( $( this.currentForm ).find( "input, select, textarea, [contenteditable]" ),
             $( this.currentForm.elements ).filter( "input, select, textarea, [contenteditable]" ) )
 			.not( ":submit, :reset, :image, :disabled" )


### PR DESCRIPTION
<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### Description
**The plugin does not validate elements that are outside of the `<form>` but have the `form` attribute on them.**

This issue occurred because in the plugin we only find input fields which are the child of form but we did not get all fields which are outside the form but associated with the form.

after analyzing the code I found the solution, at line no. 646 Did small change and it works for me.

`// Select all valid inputs inside the form (no submit or reset buttons) return $( this.currentForm ) .find( "input, select, textarea, [contenteditable]" )`

Changed above code to this
`// Select all valid inputs inside the form (no submit or reset buttons)
return $.merge( $( this.currentForm ).find( "input, select, textarea, [contenteditable]" ),
            $( this.currentForm.elements ).filter( "input, select, textarea, [contenteditable]" ) )
Thank you!
