### PR TITLE
Accept component: skip if no MIMEs are provided.

### DIFF
--- a/src/additional/accept.js
+++ b/src/additional/accept.js
@@ -1,6 +1,13 @@
 // Accept a value from a file input based on a required mimetype
 $.validator.addMethod( "accept", function( value, element, param ) {
 
+	if ( typeof param === "string" && !/.+\/.+/.test( param ) ) {
+
+		//The parameter does not have a single MIME.
+		//This rule might hence have been included by an accept tag that contains only extensions, so skip it.
+		return true;
+	}
+
 	// Split mime on commas in case we have multiple types we can accept
 	var typeParam = typeof param === "string" ? param.replace( /\s/g, "" ) : "image/*",
 		optionalValue = this.optional( element ),

--- a/test/methods.js
+++ b/test/methods.js
@@ -1794,6 +1794,20 @@ QUnit.test( "file accept - invalid mime type", function( assert ) {
 	assert.equal( proxy(), false, "the selected file for upload has invalid mime type" );
 } );
 
+QUnit.test( "file accept - only extensions", function( assert ) {
+	var input = acceptFileDummyInput( "test.kml", "foobar/vnd.google-earth.kml+xml" ),
+		$form = $( "<form />" ),
+		proxy = $.proxy( $.validator.methods.accept, new $.validator( {}, $form[ 0 ] ), null, input, "kml" );
+	assert.ok( proxy(), "the selected file for upload is validated by extensions." );
+} );
+
+QUnit.test( "file accept - extensions and MIMEs", function( assert ) {
+	var input = acceptFileDummyInput( "test.kml", "foobar/vnd.google-earth.kml+xml" ),
+		$form = $( "<form />" ),
+		proxy = $.proxy( $.validator.methods.accept, new $.validator( {}, $form[ 0 ] ), null, input, "kml,foobar/vnd.google-earth.kml+xml" );
+	assert.ok( proxy(), "the selected file for upload is validated by extensions and MIMEs." );
+} );
+
 QUnit.test( "file size - below max", function( assert ) {
 	var input = acceptFileDummyInput( "test.png", "image/png" ),
 		$form = $( "<form />" ),


### PR DESCRIPTION
<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

[X] Your code should contain tests relevant for the problem you are solving.
[X] Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
[X] The pull request should reference existing issues or link to a reproducible demo.
[X] Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### Description

The accept validation fails if a page contains a file input control, which has an accept tag that only lists extensions. In such a case, this happens even if the accept validation is not explicitly included through the rules object (static rule), as it is automatically included as an attribute rule.

My solution is to check the accept parameter for at least one MIME type. If no MIME types are specified, then validation should be passed by the accept rule itself.

I have also added two test cases. One will check that the accept rule will not fail if no MIMEs are specified, while the other will check that the accept rule will still work when a mixture of MIMEs and extensions are listed.

Related to #2271.