### PR TITLE
Core: Fix step validation problem in number type input

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1486,7 +1486,11 @@ $.extend( $.validator, {
 				re = new RegExp( "\\b" + type + "\\b" ),
 				notSupported = type && !re.test( supportedTypes.join() ),
 				decimalPlaces = function( num ) {
-					var match = ( "" + num ).match( /(?:\.(\d+))?$/ );
+					var strNum = "" + num;
+					if ( strNum.indexOf( "e-" ) > 0 ) {
+						strNum = num.toFixed( parseInt( strNum.split( "e-" )[ 1 ], 10 ) );
+					}
+					var match = strNum.match( /(?:\.(\d+))?$/ );
 					if ( !match ) {
 						return 0;
 					}


### PR DESCRIPTION
The problem is from changing the floating number to string. Bigger than -6 placement is fine. but less than -6, it changes to exponential expression like 1e-1. So there is no match the regex for separating the decimal number.

Fixes #2276