### PR TITLE
Core: Add check undefined or null for escapeCssMeta

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -950,7 +950,9 @@ $.extend( $.validator, {
 		// meta-characters that should be escaped in order to be used with JQuery
 		// as a literal part of a name/id or any selector.
 		escapeCssMeta: function( string ) {
-			return string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
+			if (string) {
+				return string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
+			}
 		},
 
 		idOrName: function( element ) {


### PR DESCRIPTION
<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### Description
For some text editors (https://github.com/Alex-D/Trumbowyg etc.) integrating, their editor element will not set name attribute or id attribute, then core.js will throws 

```
jquery.validate.min.js:4 Uncaught TypeError: Cannot read property 'replace' of undefined
    at a.validator.escapeCssMeta (jquery.validate.min.js:4)
    at a.validator.errorsFor (jquery.validate.min.js:4)
    at a.validator.prepareElement (jquery.validate.min.js:4)
    at a.validator.element (jquery.validate.min.js:4)
    at a.validator.onfocusout (jquery.validate.min.js:4)
    at HTMLDivElement.b (jquery.validate.min.js:4)
    at HTMLFormElement.dispatch (jquery.min.js:2)
    at HTMLFormElement.y.handle (jquery.min.js:2)
    at Object.trigger (jquery.min.js:2)
    at Object.simulate (jquery.min.js:2)
```
This pull request fix this issue.

Thank you!
