### PR TITLE
Reentrancy issue with remote method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1540,18 +1540,19 @@ $.extend( $.validator, {
 			var previous = this.previousValue( element, method ),
 				validator, data, optionDataString;
 
-			if ( !this.settings.messages[ element.name ] ) {
-				this.settings.messages[ element.name ] = {};
-			}
-			previous.originalMessage = previous.originalMessage || this.settings.messages[ element.name ][ method ];
-			this.settings.messages[ element.name ][ method ] = previous.message;
-
 			param = typeof param === "string" && { url: param } || param;
 			optionDataString = $.param( $.extend( { data: value }, param.data ) );
+			// execute guard before pushing this.settings.messages
 			if ( previous.old === optionDataString ) {
 				return previous.valid;
 			}
 
+			if ( !this.settings.messages[ element.name ] ) {
+
+				this.settings.messages[ element.name ] = {};
+			}
+			previous.originalMessage = previous.originalMessage || this.settings.messages[ element.name ][ method ];
+			this.settings.messages[ element.name ][ method ] = previous.message;
 			previous.old = optionDataString;
 			validator = this;
 			this.startRequest( element );


### PR DESCRIPTION
While testing a custom variant of the remote method i found that I had to move up this guard otherwise `previous.originalMessage` would get stomped on a reentrant invocation.  To be clear, I haven't confirmed this using the `remote` method directly but I am using all the same boilerplate and just changing my method name (and some details about how the response is handled).
Also I believe `previous.message` should not be getting assigned a resolved value in the case it's a function, otherwise it will always remain that static value instead of dynamically updating on the next error.
I figured it was worth mentioning.

<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### Description
<!-- Please describe your pull request. -->

Thank you!
