### PR TITLE
Update core.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1512,6 +1512,11 @@ $.extend( $.validator, {
 			if ( decimalPlaces( value ) > decimals || toInt( value ) % toInt( param ) !== 0 ) {
 				valid = false;
 			}
+			
+			//when there is no decimal places. This fixes error Please enter a multiple of 0.
+			if(decimals === 0){
+				valid = true;
+			}
 
 			return this.optional( element ) || valid;
 		},


### PR DESCRIPTION
when using jquery.validate versions later than 1.14 generate invalid numeric errors.
Error: Validation error 'Please enter a multiple of 0.' incorrectly display for Number inputs.  
The error occurs here:
if ( decimalPlaces( value ) > decimals || toInt( value ) % toInt( param ) !== 0 ) {
				valid = false;
}
even when there is no decimal places.

<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### Description
<!-- Please describe your pull request. -->

Thank you!
