### PR TITLE
Core: Fixes deprecated calls to jQuery trim. Fixes #2327

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,3 +1,12 @@
+// JQuery trim is deprecated, polyfill native js method if not defined
+if ( !String.prototype.trim ) {
+
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#Polyfill
+	String.prototype.trim = function() {
+		return this.replace( /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "" );
+	};
+}
+
 $.extend( $.fn, {
 
 	// https://jqueryvalidation.org/validate/
@@ -203,13 +212,13 @@ $.extend( $.expr.pseudos || $.expr[ ":" ], {		// '|| $.expr[ ":" ]' here enables
 
 	// https://jqueryvalidation.org/blank-selector/
 	blank: function( a ) {
-		return !$.trim( "" + $( a ).val() );
+		return !( "" + $( a ).val() ).trim();
 	},
 
 	// https://jqueryvalidation.org/filled-selector/
 	filled: function( a ) {
 		var val = $( a ).val();
-		return val !== null && !!$.trim( "" + val );
+		return val !== null && !!( "" + val ).trim();
 	},
 
 	// https://jqueryvalidation.org/unchecked-selector/

--- a/src/core.js
+++ b/src/core.js
@@ -1,10 +1,8 @@
-// JQuery trim is deprecated, polyfill native js method if not defined
-if ( !String.prototype.trim ) {
+// JQuery trim is deprecated, provide a trim method based on String.prototype.trim
+function trim( str ) {
 
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#Polyfill
-	String.prototype.trim = function() {
-		return this.replace( /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "" );
-	};
+	return str.replace( /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "" );
 }
 
 $.extend( $.fn, {
@@ -212,13 +210,13 @@ $.extend( $.expr.pseudos || $.expr[ ":" ], {		// '|| $.expr[ ":" ]' here enables
 
 	// https://jqueryvalidation.org/blank-selector/
 	blank: function( a ) {
-		return !( "" + $( a ).val() ).trim();
+		return !trim( "" + $( a ).val() );
 	},
 
 	// https://jqueryvalidation.org/filled-selector/
 	filled: function( a ) {
 		var val = $( a ).val();
-		return val !== null && !!( "" + val ).trim();
+		return val !== null && !!trim( "" + val );
 	},
 
 	// https://jqueryvalidation.org/unchecked-selector/

--- a/src/core.js
+++ b/src/core.js
@@ -1,10 +1,3 @@
-// JQuery trim is deprecated, provide a trim method based on String.prototype.trim
-function trim( str ) {
-
-	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#Polyfill
-	return str.replace( /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "" );
-}
-
 $.extend( $.fn, {
 
 	// https://jqueryvalidation.org/validate/
@@ -204,6 +197,13 @@ $.extend( $.fn, {
 		return data;
 	}
 } );
+
+// JQuery trim is deprecated, provide a trim method based on String.prototype.trim
+var trim = function( str ) {
+
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#Polyfill
+	return str.replace( /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "" );
+};
 
 // Custom selectors
 $.extend( $.expr.pseudos || $.expr[ ":" ], {		// '|| $.expr[ ":" ]' here enables backwards compatibility to jQuery 1.7. Can be removed when dropping jQ 1.7.x support


### PR DESCRIPTION
This fixes the issue with deprecation and adds the polyfill for `String.prototype.trim` for browser support.