### PR TITLE
Core: fix validation for input type="date"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1214,7 +1214,7 @@ $.extend( $.validator, {
 
 			// Exception: the jquery validate 'range' method
 			// does not test for the html5 'range' type
-			rules[ method ] = true;
+			rules[ type === "date" ? "dateISO" : method ] = true;
 		}
 	},
 


### PR DESCRIPTION
No tests here, because none are possible with methods from localization/ (quoting https://github.com/jquery-validation/jquery-validation/blob/master/test/methods.js#L186 : "need to figure out how to test localized methods")

Fixes #2359
