### PR TITLE
Prevent removal of error labels from other forms.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -670,8 +670,16 @@ $.extend( $.validator, {
 		},
 
 		errors: function() {
+			var context = this;
+			var getElementsNames = function ( elements ) {
+				return elements.map( function () { return context.idOrName( this ) });
+			}.bind( this );
+
+			var names = getElementsNames( this.elements() ).toArray();
 			var errorClass = this.settings.errorClass.split( " " ).join( "." );
-			return $( this.settings.errorElement + "." + errorClass, this.errorContext );
+			var result = $( this.settings.errorElement + "." + errorClass, this.errorContext )
+				.filter( function ( i, e ) { return names.includes( $( e ).attr( "for" )); });
+			return $( result, this.errorContext );
 		},
 
 		resetInternals: function() {
@@ -915,7 +923,7 @@ $.extend( $.validator, {
 					this.settings.unhighlight.call( this, elements[ i ], this.settings.errorClass, this.settings.validClass );
 				}
 			}
-			this.toHide = this.toHide.not( this.toShow ).filter( function ( i, e ) { return $( e ).closest( 'form' ).is( this.form ) });
+			this.toHide = this.toHide.not( this.toShow );
 			this.hideErrors();
 			this.addWrapper( this.toShow ).show();
 		},

--- a/src/core.js
+++ b/src/core.js
@@ -915,7 +915,7 @@ $.extend( $.validator, {
 					this.settings.unhighlight.call( this, elements[ i ], this.settings.errorClass, this.settings.validClass );
 				}
 			}
-			this.toHide = this.toHide.not( this.toShow );
+			this.toHide = this.toHide.not( this.toShow ).filter( function ( i, e ) { return $( e ).closest( 'form' ).is( this.form ) });
 			this.hideErrors();
 			this.addWrapper( this.toShow ).show();
 		},


### PR DESCRIPTION
#### Description
This prevents the removal of error labels that belong to another form [mostly a hidden form] placed on the current form.
These error labels do not belong to any [not ignored] element on the current form, so they should not be removed.


#### Test
https://jsfiddle.net/Lngbcrfq/10/

Leave empty all inputs.
Press `Check Name` . An error label appears next to `Name` input.
Press `Check Email` . An error label appears next to `Email` input.

Press `Check Name`  again. The error label from `Name` disappears!

#### Comments
We sometimes use hidden forms bound to inputs on a display form ([because nested forms are not a thing](https://html.spec.whatwg.org/multipage/forms.html#the-form-element)).
The bound inputs don't have names, so they are not validated on the display form.
But the validation of the display form removes the error labels from the hidden form but keeps the `errorClass` on the inputs.
The effect is that inputs have an error, but the user does not know why.

This commit filters from `errors` labels that don't belong to any element in `elements`.