### PR TITLE
Core: wait for pendingRequests to finish before submitting form

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1108,7 +1108,7 @@ $.extend( $.validator, {
 			}
 			delete this.pending[ element.name ];
 			$( element ).removeClass( this.settings.pendingClass );
-			if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() ) {
+			if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() && this.pendingRequest === 0 ) {
 				$( this.currentForm ).submit();
 
 				// Remove the hidden input that was used as a replacement for the


### PR DESCRIPTION
<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### JS Fiddle

https://jsfiddle.net/bytestream/a16ehn0L/18/

#### Description

When jquery-validation is used with a WYSIWYG editor there can be a delay in synchronisation between the `div[contenteditable]` and the underlaying `textarea`. This delay combined with remote validation leads to a state where the form is valid but does not submit.

The issue is hopefully fairly obvious when looking at `stopRequest`:
```
if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() ) {
```

`this.form()` can cause new remote validation rules to fire. In the vast majority of cases, the input data is the same and so jquery-validation looks at the cached result and doesn't bother with another AJAX request. In this case however, the delay in synchronisation causes the request data to change so jquery-validation fires another AJAX request. The line noted above currently does not wait for any new remote validation checks to return before submitting the form.

Thank you!

@staabm does this make sense?