### PR TITLE
Fix Uncaught TypeError: Cannot read property 'replace' of undefined e…

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1032,6 +1032,10 @@ $.extend( $.validator, {
 		// meta-characters that should be escaped in order to be used with JQuery
 		// as a literal part of a name/id or any selector.
 		escapeCssMeta: function( string ) {
+			if( string === undefined ){
+				console.warn("selector is undefined");
+				return;
+			}
 			return string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
 		},
 


### PR DESCRIPTION
[Many libraries](https://stackoverflow.com/search?q=Uncaught+TypeError%3A+Cannot+read+property+%27replace%27+of+undefined) that use jquery throw this error and break the code.  A warning was thrown instead of the exception.

![replaceError](https://user-images.githubusercontent.com/55924924/127770096-cec93674-7faf-4e9c-9a6d-25b40c7c88ab.png)
![replaceWarning](https://user-images.githubusercontent.com/55924924/127770099-208aeb65-e1de-49ed-a441-60c1f5426020.png)

You can see the error live on https://gurkantuna.com/Article/8/sql-test-database-rastgele-veriler. At the bottom of the page is an editor I made with ckeditor.js. You will see the error if you write something and click to the outside of the editor.

[1627818603355.log](https://github.com/jquery-validation/jquery-validation/files/6912625/localhost-1627818603355.log)
