### PR TITLE
Support case insensitivity in "pattern" method

### DIFF
--- a/src/additional/pattern.js
+++ b/src/additional/pattern.js
@@ -7,6 +7,9 @@
 * @example $.validator.methods.pattern("BR1004",element,/^AR\d{4}$/)
 * @result false
 *
+* @example $.validator.methods.pattern("ar1004",element,["AR\d{4}",true])
+* @result true
+*
 * @name $.validator.methods.pattern
 * @type Boolean
 * @cat Plugins/Validate/Methods
@@ -15,8 +18,15 @@ $.validator.addMethod( "pattern", function( value, element, param ) {
 	if ( this.optional( element ) ) {
 		return true;
 	}
-	if ( typeof param === "string" ) {
-		param = new RegExp( "^(?:" + param + ")$" );
+
+	var ignoreCase = false;
+	if ( Array.isArray( param ) ) {
+		ignoreCase = (typeof param[1] === 'boolean' && param[1]);
+		param = param[0];
+	}
+
+	if (typeof param === 'string') {
+		param = new RegExp('^(?:' + param + ')$', ignoreCase ? 'i' : '');
 	}
 	return param.test( value );
 }, "Invalid format." );

--- a/src/additional/pattern.js
+++ b/src/additional/pattern.js
@@ -18,15 +18,13 @@ $.validator.addMethod( "pattern", function( value, element, param ) {
 	if ( this.optional( element ) ) {
 		return true;
 	}
-
 	var ignoreCase = false;
 	if ( Array.isArray( param ) ) {
-		ignoreCase = (typeof param[1] === 'boolean' && param[1]);
+		ignoreCase = (typeof param[1] === "boolean" && param[1]);
 		param = param[0];
 	}
-
-	if (typeof param === 'string') {
-		param = new RegExp('^(?:' + param + ')$', ignoreCase ? 'i' : '');
+	if ( typeof param === "string" ) {
+		param = new RegExp( "^(?:" + param + ")$", ignoreCase ? "i" : "" );
 	}
 	return param.test( value );
 }, "Invalid format." );

--- a/src/additional/pattern.js
+++ b/src/additional/pattern.js
@@ -20,7 +20,7 @@ $.validator.addMethod( "pattern", function( value, element, param ) {
 	}
 	var ignoreCase = false;
 	if ( Array.isArray( param ) ) {
-		ignoreCase = (typeof param[1] === "boolean" && param[1]);
+		ignoreCase = ( typeof param[1] === "boolean" && param[1] );
 		param = param[0];
 	}
 	if ( typeof param === "string" ) {


### PR DESCRIPTION
In many cases we want to ignore casing when validating for a pattern. The proposed change enables passing an array as a param (the first element is the pattern, the second one is a boolean telling if the casing should be ignored).

<!--
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.
-->

#### Description
Adding support for case insensitivity to the "pattern" method validation.

Thank you!
