### PR TITLE
Group messages and rules - #2416

### DIFF
--- a/demo/group-messages-and-rules-demo.html
+++ b/demo/group-messages-and-rules-demo.html
@@ -20,7 +20,7 @@
 			},
 			messages: {
 				email: {
-					required: "Test override required message"
+					required: "Required message for the email field that overrides the message for the group."
 				}
 			},
 			groups: {
@@ -31,12 +31,19 @@
 						minlength: 2
 					},
 					messages: {
-						required: "Test required message.",
+						required: "Required message for the contactInfo group.",
 						minlength: jQuery.validator.format("Minimum length is {0}", 2)
 
 					}
 				},
 
+			},
+			errorPlacement: function( error, element ) {
+				if ( element.closest( ".group" ).length ) {
+					error.appendTo(element.closest( ".group" ));
+				} else {
+					error.insertAfter( element );
+				}
 			}
 		});
 	});
@@ -59,7 +66,7 @@
 	<p>Take a look at the source to see how messages can be customized with metadata.</p>
 	<!-- Custom rules and messages via data- attributes -->
 	<form class="cmxform" id="commentForm" method="post" action="">
-		<fieldset>
+		<fieldset class="group">
 			<legend>Contact Person Information</legend>
 			<p>
 				<label for="first">First Name *</label>
@@ -70,7 +77,7 @@
 				<input id="middle" name="middle" type="text">
 			</p>
 			<p>
-				<label for="first">Last Name</label>
+				<label for="last">Last Name</label>
 				<input id="last" name="last" type="text">
 			</p>
 
@@ -79,6 +86,10 @@
 				<input id="email" name="email" type="email"/>
 			</p>
 		</fieldset>
+		<p>
+			<label for="description">Description</label>
+			<textarea id="description" name="description"></textarea>
+		</p>
 		<input type="submit" value="Submit"/>
 	</form>
 

--- a/demo/group-messages-and-rules-demo.html
+++ b/demo/group-messages-and-rules-demo.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>jQuery validation plug-in - comment form example</title>
+	<link rel="stylesheet" media="screen" href="css/screen.css">
+	<script src="../lib/jquery.js"></script>
+	<script src="../dist/jquery.validate.js"></script>
+	<script>
+	$(document).ready(function() {
+
+		$("#commentForm").validate({
+			rules: {
+				middle: {
+					required: false
+				},
+				email: {
+					email: true
+				}
+			},
+			messages: {
+				email: {
+					required: "Test override required message"
+				}
+			},
+			groups: {
+				contactInfo: {
+					fields: "first middle last email",
+					rules: {
+						required: true,
+						minlength: 2
+					},
+					messages: {
+						required: "Test required message.",
+						minlength: jQuery.validator.format("Minimum length is {0}", 2)
+
+					}
+				},
+
+			}
+		});
+	});
+	</script>
+	<style>
+	form {
+		width: 500px;
+	}
+	form label {
+		width: 250px;
+	}
+	form label.error, form input.submit {
+		margin-left: 253px;
+	}
+	</style>
+</head>
+<body>
+<h1 id="banner"><a href="https://jqueryvalidation.org/">jQuery Validation Plugin</a> Demo</h1>
+<div id="main">
+	<p>Take a look at the source to see how messages can be customized with metadata.</p>
+	<!-- Custom rules and messages via data- attributes -->
+	<form class="cmxform" id="commentForm" method="post" action="">
+		<fieldset>
+			<legend>Contact Person Information</legend>
+			<p>
+				<label for="first">First Name *</label>
+				<input id="first" name="first" type="text">
+			</p>
+			<p>
+				<label for="middle">Middle Name</label>
+				<input id="middle" name="middle" type="text">
+			</p>
+			<p>
+				<label for="first">Last Name</label>
+				<input id="last" name="last" type="text">
+			</p>
+
+			<p>
+				<label for="email">Email</label>
+				<input id="email" name="email" type="email"/>
+			</p>
+		</fieldset>
+		<input type="submit" value="Submit"/>
+	</form>
+
+	<a href="index.html">Back to main page</a>
+</div>
+</body>
+</html>

--- a/src/core.js
+++ b/src/core.js
@@ -386,18 +386,42 @@ $.extend( $.validator, {
 
 			var currentForm = this.currentForm,
 				groups = ( this.groups = {} ),
-				rules;
-			$.each( this.settings.groups, function( key, value ) {
-				if ( typeof value === "string" ) {
-					value = value.split( /\s/ );
-				}
-				$.each( value, function( index, name ) {
-					groups[ name ] = key;
-				} );
-			} );
-			rules = this.settings.rules;
+				rules = this.settings.rules;
+
 			$.each( rules, function( key, value ) {
 				rules[ key ] = $.validator.normalizeRule( value );
+			} );
+
+			$.each( this.settings.groups, function( key, value ) {
+				var members = value,
+					groupRules;
+
+				if ( typeof value === "object" && !Array.isArray( value ) ) {
+					members = value.fields;
+
+				}
+				if ( typeof members === "string" ) {
+					members = members.split( /\s/ );
+				}
+
+				if (  value.hasOwnProperty( "rules" ) ) {
+					groupRules = $.validator.normalizeRule( value.rules );
+				}
+
+				$.each( members, function( index, name ) {
+
+					// Add rules for the group (individual element rules will override this)
+					if ( typeof groupRules !== "undefined" ) {
+
+						if ( typeof rules[ name ] === "undefined" ) {
+							rules[ name ] = $.validator.normalizeRule( value.rules );
+						} else {
+							rules[ name ] = $.extend( $.extend( {}, groupRules ), rules[ name ] );
+						}
+
+					}
+					groups[ name ] = key;
+				} );
 			} );
 
 			function delegate( event ) {
@@ -830,6 +854,16 @@ $.extend( $.validator, {
 			return m && ( m.constructor === String ? m : m[ method ] );
 		},
 
+		// Return custom message for group that element name is a part of (if there is one)
+		customGroupMessage: function( name, method ) {
+			if ( this.groups[ name ] && this.settings.groups[ this.groups[ name ] ].messages ) {
+				var m = this.settings.groups[ this.groups[ name ] ].messages;
+				return m && ( m.constructor === String ? m : m[ method ] );
+			} else {
+				return undefined;
+			}
+		},
+
 		// Return the first defined argument, allowing empty strings
 		findDefined: function() {
 			for ( var i = 0; i < arguments.length; i++ ) {
@@ -857,6 +891,7 @@ $.extend( $.validator, {
 			var message = this.findDefined(
 					this.customMessage( element.name, rule.method ),
 					this.customDataMessage( element, rule.method ),
+					this.customGroupMessage( element.name, rule.method ),
 
 					// 'title' is never undefined, so handle empty string as undefined
 					!this.settings.ignoreTitle && element.title || undefined,
@@ -1032,7 +1067,7 @@ $.extend( $.validator, {
 		// meta-characters that should be escaped in order to be used with JQuery
 		// as a literal part of a name/id or any selector.
 		escapeCssMeta: function( string ) {
-			if (string === undefined) return "";
+			if ( string === undefined ) { return ""; }
 			return string.replace( /([\\!"#$%&'()*+,./:;<=>?@\[\]^`{|}~])/g, "\\$1" );
 		},
 

--- a/test/index.html
+++ b/test/index.html
@@ -133,6 +133,30 @@
 		<input id="toDate" name="toDate" class="requiredDateRange" value="y">
 		<span class="errorContainer"></span>
 	</form>
+	<form id="groupMessages">
+		<fieldset class="group">
+			<legend>Contact Person Information</legend>
+
+				<label for="groupMessagesFirst">First Name *</label>
+				<input id="groupMessagesFirst" name="groupMessagesFirst" type="text">
+
+				<label for="groupMessagesMiddle">Middle Name</label>
+				<input id="groupMessagesMiddle" name="groupMessagesMiddle" type="text">
+
+				<label for="groupMessagesLast">Last Name</label>
+				<input id="groupMessagesLast" name="groupMessagesLast" type="text">
+
+
+				<label for="groupMessagesEmail">Email</label>
+				<input id="groupMessagesEmail" name="groupMessagesEmail" type="email"/>
+
+		</fieldset>
+
+			<label for="groupMessagesDescription">Description</label>
+			<textarea id="groupMessagesDescription" name="groupMessagesDescription"></textarea>
+
+		<input type="submit" value="Submit" id="groupMessagesSubmit"/>
+	</form>
 	<form id="testForm8">
 		<input id="form8input" data-rule-required="true" data-rule-number="true" data-rule-rangelength="2,8" name="abc">
 		<input type="radio" name="radio1">
@@ -282,6 +306,30 @@
 		<input id="v2-i7" name="v2-i7" data-rule-number data-rule-required>
 		<input id="v2-i8" name="v2-i8" data-rule-number="" data-rule-required="">
 		<input id="v2-i9" name="v2-i9">
+	</form>
+	<form id="groupRules">
+		<fieldset class="group">
+			<legend>Contact Person Information</legend>
+
+				<label for="groupRulesFirst">First Name *</label>
+				<input id="groupRulesFirst" name="groupRulesFirst" type="text">
+
+				<label for="groupRulesMiddle">Middle Name</label>
+				<input id="groupRulesMiddle" name="groupRulesMiddle" type="text">
+
+				<label for="groupRulesLast">Last Name</label>
+				<input id="groupRulesLast" name="groupRulesLast" type="text">
+
+
+				<label for="groupRulesEmail">Email</label>
+				<input id="groupRulesEmail" name="groupRulesEmail" type="Email"/>
+
+		</fieldset>
+
+			<label for="groupRulesDescription">Description</label>
+			<textarea id="groupRulesDescription" name="groupRulesDescription"></textarea>
+
+		<input type="submit" value="Submit" id="groupRulesSubmit"/>
 	</form>
 	<form id="checkables">
 		<input type="checkbox" id="checkable1" name="checkablesgroup" class="required">
@@ -448,12 +496,12 @@
 		<input name="year"/>
 		<button name="submitForm27" value="someValue" type="submit"><span>Submit</span></button>
 	</form>
-	
+
 	<form id="cnhFormTest">
 		<input id="cnhnumber" name="cnhnumber" required>
 		<button name="submitFormCnh" value="submitFormCnh" type="submit"><span>Submit</span></button>
 	</form>
-	
+
 	<form id="_contenteditableForm">
 		<div name="first_name" id="first_name" contenteditable placeholder="First Name"></div>
 		<br>

--- a/test/messages.js
+++ b/test/messages.js
@@ -42,7 +42,58 @@ QUnit.test( "group error messages", function( assert ) {
 	assert.ok( form.valid() );
 	assert.ok( form.find( ".errorContainer .error:not(input)" ).is( ":hidden" ) );
 } );
+QUnit.test( "error messages set for group ", function( assert ) {
+	var email = $( "#groupMessagesEmail" ),
+		form = $( "#groupMessages" ),
+		emailRequiredMessage = "Required message for the email field that overrides the message for the group.",
+		groupRequiredMessage = "Required message for the contactInfo group.";
 
+	$( "#groupMessages" ).validate( {
+		rules: {
+			groupMessagesMiddle: {
+				required: false
+			},
+			groupMessagesEmail: {
+				email: true
+			}
+		},
+		messages: {
+			groupMessagesEmail: {
+				required: emailRequiredMessage
+			}
+		},
+		groups: {
+			contactInfo: {
+				fields: "groupMessagesFirst groupMessagesMiddle groupMessagesLast groupMessagesEmail",
+				rules: {
+					required: true,
+					minlength: 2
+				},
+				messages: {
+					required: groupRequiredMessage,
+					minlength: jQuery.validator.format( "Minimum length is {0}", 2 )
+
+				}
+			}
+
+		},
+		errorPlacement: function( error, element ) {
+			if ( element.closest( ".group" ).length ) {
+				error.appendTo( element.closest( ".group" ) );
+			} else {
+				error.insertAfter( element );
+			}
+		}
+	} );
+
+	assert.ok( !form.valid() );
+	assert.equal( form.find( "#contactInfo-error" ).length, 1 );
+	assert.equal( form.find( "#contactInfo-error" ).text(), emailRequiredMessage );
+	email.val( "test@sfhsuidfhiusdfs.test" );
+	email.trigger( "blur" );
+	assert.equal( form.find( "#contactInfo-error" ).text(), groupRequiredMessage );
+
+} );
 QUnit.test( "read messages from metadata", function( assert ) {
 	var form = $( "#testForm9" ),
 		e, g;

--- a/test/rules.js
+++ b/test/rules.js
@@ -48,6 +48,42 @@ QUnit.test( "rules() - external", function( assert ) {
 	assert.deepEqual( element.rules(), { date: true, min: 5 } );
 } );
 
+QUnit.test( "rules() - group ", function( assert ) {
+	var first = $( "#groupRulesFirst" ),
+		middle = $( "#groupRulesMiddle" ),
+		email = $( "#groupRulesEmail" );
+
+	$( "#groupRules" ).validate( {
+		rules: {
+			groupRulesMiddle: {
+				required: false
+			},
+			groupRulesEmail: {
+				email: true
+			}
+		},
+		groups: {
+			contactInfo: {
+				fields: "groupRulesFirst groupRulesMiddle groupRulesLast groupRulesEmail",
+				rules: {
+					required: true,
+					minlength: 2
+				},
+				messages: {
+					required: "Required message for the contactInfo group.",
+					minlength: jQuery.validator.format( "Minimum length is {0}", 2 )
+
+				}
+			}
+		}
+	} );
+
+	assert.deepEqual( first.rules(), { required: true, minlength: 2 } );
+
+	// Rules that are set to false should be deleted
+	assert.deepEqual( middle.rules(), { minlength: 2 } );
+	assert.deepEqual( email.rules(), { required: true, minlength: 2, email: true } );
+} );
 QUnit.test( "rules() - external - complete form", function( assert ) {
 	assert.expect( 1 );
 


### PR DESCRIPTION
Resolves https://github.com/jquery-validation/jquery-validation/issues/2416 feature request

Groups can now be objects with their own rules and messages that become the default for each field in the group. Those can be overridden for any individual fields. (This seems more valuable for rules and message functions than message strings, but I wanted to be consistent.)
