### PR TITLE
Core: fix deprecated jquery .submit() event shorthand

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1113,7 +1113,7 @@ $.extend( $.validator, {
 			delete this.pending[ element.name ];
 			$( element ).removeClass( this.settings.pendingClass );
 			if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() && this.pendingRequest === 0 ) {
-				$( this.currentForm ).submit();
+				$( this.currentForm ).trigger( 'submit' );
 
 				// Remove the hidden input that was used as a replacement for the
 				// missing submit button. The hidden input is added by `handle()`

--- a/src/core.js
+++ b/src/core.js
@@ -1113,7 +1113,7 @@ $.extend( $.validator, {
 			delete this.pending[ element.name ];
 			$( element ).removeClass( this.settings.pendingClass );
 			if ( valid && this.pendingRequest === 0 && this.formSubmitted && this.form() && this.pendingRequest === 0 ) {
-				$( this.currentForm ).trigger( 'submit' );
+				$( this.currentForm ).trigger( "submit" );
 
 				// Remove the hidden input that was used as a replacement for the
 				// missing submit button. The hidden input is added by `handle()`


### PR DESCRIPTION
Fixes `jQuery.fn.submit() event shorthand is deprecated`

https://github.com/jquery/jquery-migrate/blob/main/warnings.md#shorthand-deprecated-v3-jqmigrate-jqueryfnclick-event-shorthand-is-deprecated
