### PR TITLE
Core: fix race condition in remote validation rules

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,5 +1,6 @@
 // Ajax mode: abort
 // usage: $.ajax({ mode: "abort"[, port: "uniqueport"]});
+//        $.ajaxAbort( port );
 // if mode:"abort" is used, the previous request on that port (port can be undefined) is aborted via XMLHttpRequest.abort()
 
 var pendingRequests = {},
@@ -10,9 +11,7 @@ if ( $.ajaxPrefilter ) {
 	$.ajaxPrefilter( function( settings, _, xhr ) {
 		var port = settings.port;
 		if ( settings.mode === "abort" ) {
-			if ( pendingRequests[ port ] ) {
-				pendingRequests[ port ].abort();
-			}
+			$.ajaxAbort( port );
 			pendingRequests[ port ] = xhr;
 		}
 	} );
@@ -24,12 +23,18 @@ if ( $.ajaxPrefilter ) {
 		var mode = ( "mode" in settings ? settings : $.ajaxSettings ).mode,
 			port = ( "port" in settings ? settings : $.ajaxSettings ).port;
 		if ( mode === "abort" ) {
-			if ( pendingRequests[ port ] ) {
-				pendingRequests[ port ].abort();
-			}
+			$.ajaxAbort( port );
 			pendingRequests[ port ] = ajax.apply( this, arguments );
 			return pendingRequests[ port ];
 		}
 		return ajax.apply( this, arguments );
 	};
 }
+
+// Abort the previous request without sending a new one
+$.ajaxAbort = function( port ) {
+	if ( pendingRequests[ port ] ) {
+		pendingRequests[ port ].abort();
+		delete pendingRequests[ port ];
+	}
+};

--- a/test/methods.js
+++ b/test/methods.js
@@ -801,6 +801,36 @@ QUnit.test( "Fix #697: remote validation uses wrong error messages", function( a
 	} );
 } );
 
+QUnit.test( "Fix #2434: race condition in remote validation rules", function( assert ) {
+	var e = $( "#username" ),
+		done1 = assert.async(),
+		v = $( "#userForm" ).validate( {
+			rules: {
+				username: {
+					required: true,
+					remote: {
+						url: "users.php"
+					}
+				}
+			},
+			messages: {
+				username: {
+					remote: $.validator.format( "{0} in use" )
+				}
+			}
+		} );
+
+	e.val( "Peter" );
+	v.element( e );
+
+	e.val( "" );
+	v.element( e );
+	setTimeout( function() {
+		assert.equal( v.errorList[ 0 ].message, "This field is required." );
+		done1();
+	} );
+} );
+
 QUnit.module( "additional methods" );
 
 QUnit.test( "phone (us)", function( assert ) {


### PR DESCRIPTION
Fixes #2434

#### Description

- Add a new jQuery global method `$.ajaxAbort( port )` to the jQuery Ajax extension that is provided by this library. This method allows to abort an ajax request without sending a new one.
- Call this method at the beginning of `check()` method.
