### PR TITLE
Core: remove pending class from fields with an aborted request

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1152,6 +1152,7 @@ $.extend( $.validator, {
 				}
 
 				delete this.pending[ element.name ];
+				$( element ).removeClass( this.settings.pendingClass );
 			}
 		},
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -822,11 +822,19 @@ QUnit.test( "Fix #2434: race condition in remote validation rules", function( as
 
 	e.val( "Peter" );
 	v.element( e );
+	assert.equal( e.hasClass( "error" ), false, "Field 'username' should not have the error class" );
+	assert.equal( e.hasClass( "pending" ), true, "field 'username' should have the pending class" );
 
 	e.val( "" );
 	v.element( e );
+	assert.equal( v.errorList[ 0 ].message, "This field is required." );
+	assert.equal( e.hasClass( "error" ), true, "Field 'username' should have the error class" );
+	assert.equal( e.hasClass( "pending" ), false, "field 'username' should not have the pending class" );
+
 	setTimeout( function() {
 		assert.equal( v.errorList[ 0 ].message, "This field is required." );
+		assert.equal( e.hasClass( "error" ), true, "Field 'username' should have the error class" );
+		assert.equal( e.hasClass( "pending" ), false, "field 'username' should not have the pending class" );
 		done1();
 	} );
 } );


### PR DESCRIPTION
Ref #2434
Ref #2435

#### Description

Follow up on #2435. Removal of the pending class from element was missing.

