### PR TITLE
Localization: small improvement to pt_BR

### DIFF
--- a/src/localization/messages_pt_BR.js
+++ b/src/localization/messages_pt_BR.js
@@ -6,7 +6,7 @@
 $.extend( $.validator.messages, {
 
 	// Core
-	required: "Este campo &eacute; requerido.",
+	required: "Este campo &eacute; obrigat&oacute;rio.",
 	remote: "Por favor, corrija este campo.",
 	email: "Por favor, forne&ccedil;a um endere&ccedil;o de email v&aacute;lido.",
 	url: "Por favor, forne&ccedil;a uma URL v&aacute;lida.",


### PR DESCRIPTION



#### Description
"É requerido" although correct is weird in this context (it's much more used in formal settings for documents known as requerimentos) and too much of a literal translation. This change aims to improve user-friendliness in this particular message.

**Popularity of one vs the other:**
![image](https://user-images.githubusercontent.com/4926869/195453677-87954c84-22e5-4bbd-bd70-22953e11bb28.png)

**Demonstration of how the adjective requerido is much more widely used in judicial settings:**
![image](https://user-images.githubusercontent.com/4926869/195453968-0db8fc8d-7f07-4224-8b95-17fba976bc0b.png)

(Jus brasil is one of the go-to websites as a judicial source and "cpc"/"codigo civil" both refer to brazil's civil laws)

Thank you!
