### PR TITLE
Fixed addClassRules to allow "messages"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1205,10 +1205,17 @@ $.extend( $.validator, {
 
 	addClassRules: function( className, rules ) {
 		if ( className.constructor === String ) {
-			this.classRuleSettings[ className ] = rules;
-		} else {
-			$.extend( this.classRuleSettings, className );
+			var obj = {};
+			obj[className] = rules;
+			className = obj;
 		}
+
+		$.each(className, function (n, r) {
+			$("." + n).each(function (i, e) {
+				var self = j(e)
+				self.rules('add', r);
+			});
+		});
 	},
 
 	classRules: function( element ) {


### PR DESCRIPTION
Adding message in `addClassRules` wasn't working, following solution posted in #1442 it worked.
