### PR TITLE
Demo: fix minlength validation in ajaxSubmit-integration-demo.html

### DIFF
--- a/demo/ajaxSubmit-integration-demo.html
+++ b/demo/ajaxSubmit-integration-demo.html
@@ -74,7 +74,7 @@
 			</p>
 			<p>
 				<label for="pass">Password</label>
-				<input type="password" name="password" id="password" class="required" minlength "5">
+				<input type="password" name="password" id="password" class="required" minlength="5">
 			</p>
 			<p>
 				<input class="submit" type="submit" value="Login">


### PR DESCRIPTION
This fixes attribute assignment it was `minlength "5"` but it needs the `=` equal sign.