### PR TITLE
Core: Added escapeHtml option to avoid XSS attacks via showLabel method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -945,14 +945,23 @@ $.extend( $.validator, {
 				error.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
 
 				// Replace message on existing label
-				error.html( message );
+				if ( this.settings && this.settings.escapeHtml ) {
+					error.text( message || "" );
+				} else {
+					error.html( message || "" );
+				}
 			} else {
 
 				// Create error element
 				error = $( "<" + this.settings.errorElement + ">" )
 					.attr( "id", elementID + "-error" )
-					.addClass( this.settings.errorClass )
-					.html( message || "" );
+					.addClass( this.settings.errorClass );
+
+				if ( this.settings && this.settings.escapeHtml ) {
+					error.text( message || "" );
+				} else {
+					error.html( message || "" );
+				}
 
 				// Maintain reference to the element to be placed into the DOM
 				place = error;

--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -440,3 +440,60 @@ QUnit.test( "#1632: Error hidden, but input error class not removed", function( 
 	assert.equal( v.numberOfInvalids(), 0, "There is no error" );
 	assert.equal( box2.hasClass( "error" ), false, "Box2 should not have an error class" );
 } );
+
+QUnit.test( "test settings.escapeHtml undefined", function( assert ) {
+	var form = $( "#escapeHtmlForm1" ),
+		field = $( "#escapeHtmlForm1text" );
+
+	form.validate( {
+		messages: {
+			escapeHtmlForm1text: {
+				required: "<script>console.log('!!!');</script>"
+			}
+		}
+	} );
+
+	assert.ok( !field.valid() );
+	assert.hasError( field, "required" );
+
+	var label = form.find( "label" );
+	assert.equal( label.length, 1 );
+	assert.equal( label.html(), "<script>console.log('!!!');</script>" );
+
+	label.html( "" );
+	assert.ok( !field.valid() );
+	assert.equal( label.html(), "<script>console.log('!!!');</script>" );
+
+	field.val( "foo" );
+	assert.ok( field.valid() );
+	assert.noErrorFor( field );
+} );
+
+QUnit.test( "test settings.escapeHtml true", function( assert ) {
+	var form = $( "#escapeHtmlForm2" ),
+		field = $( "#escapeHtmlForm2text" );
+
+	form.validate( {
+		escapeHtml: true,
+		messages: {
+			escapeHtmlForm2text: {
+				required: "<script>console.log('!!!');</script>"
+			}
+		}
+	} );
+
+	assert.ok( !field.valid() );
+	assert.hasError( field, "required" );
+
+	var label = form.find( "label" );
+	assert.equal( label.length, 1 );
+	assert.equal( label.html(), "&lt;script&gt;console.log('!!!');&lt;/script&gt;" );
+
+	label.html( "" );
+	assert.ok( !field.valid() );
+	assert.equal( label.html(), "&lt;script&gt;console.log('!!!');&lt;/script&gt;" );
+
+	field.val( "foo" );
+	assert.ok( field.valid() );
+	assert.noErrorFor( field );
+} );

--- a/test/index.html
+++ b/test/index.html
@@ -467,6 +467,12 @@
 	<form id="testForm28">
 		<input type="text" name="f28input" required>
 	</form>
+	<form id="escapeHtmlForm1">
+		<input name="escapeHtmlForm1text" id="escapeHtmlForm1text" data-rule-required="true" />
+	</form>	
+	<form id="escapeHtmlForm2">
+		<input name="escapeHtmlForm2text" id="escapeHtmlForm2text" data-rule-required="true" />
+	</form>	
 </div>
 </body>
 </html>


### PR DESCRIPTION
This adds a new constructor option "escapeHtml".

There is a script injection risk if the messages set via $.validator.messages etc. are originating from a user localizable dictionary, like a translation screen as the showLabel function uses .html() to set the label content. Even in cases where that is not an issue, if the message itself contains a format placeholder like "{0} is not valid value for this field", as the value passed to {0} is a user input, it still provides an opportunity for script injection attacks albeit at a lower risk.
