### PR TITLE
Localization: Add French currency translation

### DIFF
--- a/src/localization/messages_fr.js
+++ b/src/localization/messages_fr.js
@@ -41,6 +41,7 @@ $.extend( $.validator.messages, {
 	email2: "Veuillez fournir une adresse électronique valide.",
 	url2: "Veuillez fournir une adresse URL valide.",
 	creditcardtypes: "Veuillez fournir un numéro de carte de crédit valide.",
+	currency: "Veuillez fournir une monnaie valide.",
 	ipv4: "Veuillez fournir une adresse IP v4 valide.",
 	ipv6: "Veuillez fournir une adresse IP v6 valide.",
 	require_from_group: $.validator.format( "Veuillez fournir au moins {0} de ces champs." ),


### PR DESCRIPTION
This adds a French translation message for the [currency validation method](https://github.com/jquery-validation/jquery-validation/blob/master/src/additional/currency.js).

Just for reference, the English version of this message is:
> Please specify a valid currency.