### PR TITLE
Core: fix remote validation when input is the same as in aborted request

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1594,11 +1594,12 @@ $.extend( $.validator, {
 
 			param = typeof param === "string" && { url: param } || param;
 			optionDataString = $.param( $.extend( { data: value }, param.data ) );
-			if ( previous.old === optionDataString ) {
+			if ( previous.valid !== null && previous.old === optionDataString ) {
 				return previous.valid;
 			}
 
 			previous.old = optionDataString;
+			previous.valid = null;
 			validator = this;
 			this.startRequest( element );
 			data = {};

--- a/test/methods.js
+++ b/test/methods.js
@@ -623,7 +623,7 @@ QUnit.test( "remote, data previous querystring", function( assert ) {
 			rules: {
 				lastname: {
 					remote: {
-						url: "users.php",
+						url: "users3.php",
 						type: "POST",
 						data: {
 							firstname: function() {
@@ -833,6 +833,42 @@ QUnit.test( "Fix #2434: race condition in remote validation rules", function( as
 
 	setTimeout( function() {
 		assert.equal( v.errorList[ 0 ].message, "This field is required." );
+		assert.equal( e.hasClass( "error" ), true, "Field 'username' should have the error class" );
+		assert.equal( e.hasClass( "pending" ), false, "field 'username' should not have the pending class" );
+		done1();
+	} );
+} );
+
+QUnit.test( "Fix #2479: Remote validation fails when input is the same as in aborted request", function( assert ) {
+	var e = $( "#username" ),
+		done1 = assert.async(),
+		v = $( "#userForm" ).validate( {
+			rules: {
+				username: {
+					remote: {
+						url: "users.php"
+					}
+				}
+			},
+			messages: {
+				username: {
+					remote: $.validator.format( "{0} in use" )
+				}
+			}
+		} );
+
+	e.val( "Peter" );
+	v.element( e );
+	assert.equal( e.hasClass( "error" ), false, "Field 'username' should not have the error class" );
+	assert.equal( e.hasClass( "pending" ), true, "field 'username' should have the pending class" );
+
+	e.val( "Peter" );
+	v.element( e );
+	assert.equal( e.hasClass( "error" ), false, "Field 'username' should not have the error class" );
+	assert.equal( e.hasClass( "pending" ), true, "field 'username' should have the pending class" );
+
+	setTimeout( function() {
+		assert.equal( v.errorList[ 0 ].message, "Peter in use" );
 		assert.equal( e.hasClass( "error" ), true, "Field 'username' should have the error class" );
 		assert.equal( e.hasClass( "pending" ), false, "field 'username' should not have the pending class" );
 		done1();

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,16 @@ $.mockjax( {
 } );
 
 $.mockjax( {
+	url: "users3.php",
+	data: {
+		lastname: "last-name"
+	},
+	responseText: "false",
+	responseStatus: 200,
+	responseTime: 1
+} );
+
+$.mockjax( {
 	url: "echo.php",
 	response: function( data ) {
 		this.responseText = JSON.stringify( data.data );


### PR DESCRIPTION
Fixes #2479

#### Description

There is a bug in remote validation: if the Ajax request for a remote validation rule fails, an incorrect result will be stored in `$element.data('previousValue')`. Then, if the same input is validated again, the previous incorrect result will be re-used and no Ajax request will be sent.

In particular, this bug will occur when a request is aborted. Which happens more often (as it should) since #2435 was merged. (although the bug could already occur before #2435 in case of a server error).

I also had to fix the `"remote, data previous querystring"` test. It turns out the mocked request for this test was wrong. Which didn't matter before this PR: the failed remote validation was incorrectly considered as a validation result.