### PR TITLE
Create phoneIT.js

### DIFF
--- a/src/additional/phoneIT.js
+++ b/src/additional/phoneIT.js
@@ -1,0 +1,6 @@
+/**
+ * Italian phone numbers have 9-10 digits (and start with +39 or 0039).
+ */
+$.validator.addMethod( "phoneIT", function( value, element ) {
+	return this.optional( element ) || /^((00|\+)39)[\d]{9,10}$/.test( value );
+},"Please specify a valid phone number." );


### PR DESCRIPTION
Add Italian phone number validation method

Summary:
Added a new validation method `phoneIT`. This method allows the validation of Italian phone numbers according to the standard format used in Italy.

Details:
- Added the `phoneIT` method to validate Italian phone numbers.
- The method checks whether the input follows the format of Italian phone numbers, including the country code (+39).

Usage:
```javascript
$( "#myForm" ).validate({
  rules: {
    phone: {
      required: true,
      phoneIT: true
    }
  }
});
