### PR TITLE
Core: Validate inputs with duplicate name / name[] arrays, instead of just the first item

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -453,9 +453,22 @@ $.extend( $.validator, {
 		},
 
 		checkForm: function() {
+			var checkedCache = {};
+			
 			this.prepareForm();
 			for ( var i = 0, elements = ( this.currentElements = this.elements() ); elements[ i ]; i++ ) {
-				this.check( elements[ i ] );
+				var element = elements[ i ];
+				
+				var type = element.attr( "type" );
+				if ( type === 'checkbox' || type === 'radio' ) {
+					// only check the first checkbox/radio input ( https://github.com/jquery-validation/jquery-validation/pull/2431#issuecomment-1172835268 )
+					if ( element.name in checkedCache ) {
+						continue;
+					}
+					checkedCache[ element.name ] = true;
+				}
+				
+				this.check( element );
 			}
 			return this.valid();
 		},
@@ -657,8 +670,12 @@ $.extend( $.validator, {
 					return false;
 				}
 
-				// Select only the first element for each name, and only those with rules specified
-				if ( name in rulesCache || !validator.objectLength( $( this ).rules() ) ) {
+				if ( name in rulesCache ) {
+					return true;
+				}
+
+				// return only those with rules specified
+				if ( !validator.objectLength( $( this ).rules() ) ) {
 					return false;
 				}
 

--- a/src/core.js
+++ b/src/core.js
@@ -457,7 +457,7 @@ $.extend( $.validator, {
 			
 			this.prepareForm();
 			for ( var i = 0, elements = ( this.currentElements = this.elements() ); elements[ i ]; i++ ) {
-				var element = elements[ i ];
+				var element = elements.eq(i);
 				
 				var type = element.attr( "type" );
 				if ( type === 'checkbox' || type === 'radio' ) {


### PR DESCRIPTION
#### Description

Replaces #2000 and #2431 with simpler logic, and I believe that .elements() should return all of the eligible elements.

Previously, if you had 2+ inputs using name arrays, such as:
```html
<input type="text" name="todo_item[]" data-rule-required="true" />
<input type="text" name="todo_item[]" data-rule-required="true" />
<input type="text" name="todo_item[]" data-rule-required="true" />
```

It would only hit validation on the first input in the array, allowing all the remaining inputs with the same name to remain empty.

Technically, I'm pretty sure the following, without using [] syntax would have the same problem:
```html
<input type="text" name="first_name" data-rule-required="true" />
<input type="text" name="first_name" data-rule-required="true" />
<input type="text" name="first_name" data-rule-required="true" />
```

I'm not familiar with the testing framework, but please review the idea behind this PR first, and if you're confident that it will be merged if tests are included, I'll dig deeper into testing.