### PR TITLE
Chore: downgrade ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     linux_tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             - uses: actions/checkout@v3


### PR DESCRIPTION
Puppeteer broken on ubuntu-24.04 - https://github.com/puppeteer/puppeteer/issues/12818#issuecomment-2684634479