### PR TITLE
Localization: Add Norwegian Nynorsk (nn) messages

### DIFF
--- a/src/localization/messages_nn.js
+++ b/src/localization/messages_nn.js
@@ -1,0 +1,23 @@
+/*
+ * Translated default messages for the jQuery validation plugin.
+ * Locale: NN (Norwegian Nynorsk; Norsk nynorsk)
+ */
+$.extend( $.validator.messages, {
+	required: "Oppgi ein verdi.",
+	remote: "Ugyldig verdi.",
+	email: "Oppgi ei gyldig e-postadresse.",
+	url: "Oppgi ei gyldig nettadresse.",
+	date: "Oppgi ein gyldig dato.",
+	dateISO: "Oppgi ein gyldig dato (ÅÅÅÅ-MM-DD).",
+	number: "Oppgi eit gyldig tal.",
+	digits: "Skriv berre tal.",
+	equalTo: "Skriv same verdi igjen.",
+	maxlength: $.validator.format( "Maksimalt {0} teikn." ),
+	minlength: $.validator.format( "Minimum {0} teikn." ),
+	rangelength: $.validator.format( "Oppgi minimum {0} og maksimum {1} teikn." ),
+	range: $.validator.format( "Oppgi ein verdi mellom {0} og {1}." ),
+	max: $.validator.format( "Oppgi ein verdi som er mindre enn eller lik {0}." ),
+	min: $.validator.format( "Oppgi ein verdi som er større enn eller lik {0}." ),
+	step: $.validator.format( "Oppgi ein verdi som er eit multiplum av {0}." ),
+	creditcard: "Oppgi eit gyldig kredittkortnummer."
+} );


### PR DESCRIPTION
Adds Norwegian **Nynorsk** (`messages_nn.js`). The plugin already ships `messages_no.js` (Bokmål-style Norwegian); this adds Norway's other official written standard, same message set.

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian speaker.